### PR TITLE
[Bug] Not to assign a default value (None) to `num_iterations` parameter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytorch_optimizer"
-version = "1.1.1"
+version = "1.1.2"
 description = "Bunch of optimizer implementations in PyTorch with clean-code, strict types. Also, including useful optimization ideas."
 license = "Apache-2.0"
 authors = ["kozistr <kozistr@gmail.com>"]

--- a/pytorch_optimizer/ranger21.py
+++ b/pytorch_optimizer/ranger21.py
@@ -41,12 +41,12 @@ class Ranger21(Optimizer, BaseOptimizer):
     def __init__(
         self,
         params: PARAMETERS,
+        num_iterations: int,
         lr: float = 1e-3,
         beta0: float = 0.9,
         betas: BETAS = (0.9, 0.999),
         use_softplus: bool = True,
         beta_softplus: float = 50.0,
-        num_iterations: Optional[int] = None,
         num_warm_up_iterations: Optional[int] = None,
         num_warm_down_iterations: Optional[int] = None,
         warm_down_min_lr: float = 3e-5,
@@ -68,8 +68,8 @@ class Ranger21(Optimizer, BaseOptimizer):
         :param betas: BETAS. coefficients used for computing running averages of gradient and the squared hessian trace
         :param use_softplus: bool. use softplus to smooth
         :param beta_softplus: float. beta
-        :param agc_clipping_value: float
-        :param agc_eps: float
+        :param agc_clipping_value: float.
+        :param agc_eps: float. eps for AGC
         :param centralize_gradients: bool. use GC both convolution & fc layers
         :param normalize_gradients: bool. use gradient normalization
         :param lookahead_merge_time: int. merge time

--- a/tests/test_optimizer_parameters.py
+++ b/tests/test_optimizer_parameters.py
@@ -120,10 +120,16 @@ def test_betas(optimizer_name):
     optimizer = load_optimizer(optimizer_name)
 
     with pytest.raises(ValueError):
-        optimizer(None, betas=(-0.1, 0.1))
+        if optimizer_name == 'ranger21':
+            optimizer(None, num_iterations=100, betas=(-0.1, 0.1))
+        else:
+            optimizer(None, betas=(-0.1, 0.1))
 
     with pytest.raises(ValueError):
-        optimizer(None, betas=(0.1, -0.1))
+        if optimizer_name == 'ranger21':
+            optimizer(None, num_iterations=100, betas=(0.1, -0.1))
+        else:
+            optimizer(None, betas=(0.1, -0.1))
 
     if optimizer_name == 'adapnm':
         with pytest.raises(ValueError):
@@ -131,8 +137,7 @@ def test_betas(optimizer_name):
 
 
 def test_reduction():
-    model: nn.Module = Example()
-    parameters = model.parameters()
+    parameters = Example().parameters()
     optimizer = load_optimizer('adamp')(parameters)
 
     with pytest.raises(ValueError):

--- a/tests/test_optimizer_parameters.py
+++ b/tests/test_optimizer_parameters.py
@@ -40,74 +40,84 @@ BETA_OPTIMIZER_NAMES: List[str] = [
 ]
 
 
-@pytest.mark.parametrize('optimizer_names', OPTIMIZER_NAMES + ['nero'])
-def test_learning_rate(optimizer_names):
+@pytest.mark.parametrize('optimizer_name', OPTIMIZER_NAMES + ['nero'])
+def test_learning_rate(optimizer_name):
+    optimizer = load_optimizer(optimizer_name)
+
     with pytest.raises(ValueError):
-        optimizer = load_optimizer(optimizer_names)
-        optimizer(None, lr=-1e-2)
+        if optimizer_name == 'ranger21':
+            optimizer(None, num_iterations=100, lr=-1e-2)
+        else:
+            optimizer(None, lr=-1e-2)
 
 
-@pytest.mark.parametrize('optimizer_names', OPTIMIZER_NAMES)
-def test_epsilon(optimizer_names):
+@pytest.mark.parametrize('optimizer_name', OPTIMIZER_NAMES)
+def test_epsilon(optimizer_name):
+    optimizer = load_optimizer(optimizer_name)
+
     with pytest.raises(ValueError):
-        optimizer = load_optimizer(optimizer_names)
-        optimizer(None, eps=-1e-6)
+        if optimizer_name == 'ranger21':
+            optimizer(None, num_iterations=100, eps=-1e-6)
+        else:
+            optimizer(None, eps=-1e-6)
 
 
-@pytest.mark.parametrize('optimizer_names', OPTIMIZER_NAMES)
-def test_weight_decay(optimizer_names):
+@pytest.mark.parametrize('optimizer_name', OPTIMIZER_NAMES)
+def test_weight_decay(optimizer_name):
+    optimizer = load_optimizer(optimizer_name)
+
     with pytest.raises(ValueError):
-        optimizer = load_optimizer(optimizer_names)
-        optimizer(None, weight_decay=-1e-3)
+        if optimizer_name == 'ranger21':
+            optimizer(None, num_iterations=100, weight_decay=-1e-3)
+        else:
+            optimizer(None, weight_decay=-1e-3)
 
 
-@pytest.mark.parametrize('optimizer_names', ['adamp', 'sgdp'])
-def test_wd_ratio(optimizer_names):
+@pytest.mark.parametrize('optimizer_name', ['adamp', 'sgdp'])
+def test_wd_ratio(optimizer_name):
+    optimizer = load_optimizer(optimizer_name)
     with pytest.raises(ValueError):
-        optimizer = load_optimizer(optimizer_names)
         optimizer(None, wd_ratio=-1e-3)
 
 
-@pytest.mark.parametrize('optimizer_names', ['lars'])
-def test_trust_coefficient(optimizer_names):
+@pytest.mark.parametrize('optimizer_name', ['lars'])
+def test_trust_coefficient(optimizer_name):
+    optimizer = load_optimizer(optimizer_name)
     with pytest.raises(ValueError):
-        optimizer = load_optimizer(optimizer_names)
         optimizer(None, trust_coefficient=-1e-3)
 
 
-@pytest.mark.parametrize('optimizer_names', ['madgrad', 'lars'])
-def test_momentum(optimizer_names):
+@pytest.mark.parametrize('optimizer_name', ['madgrad', 'lars'])
+def test_momentum(optimizer_name):
+    optimizer = load_optimizer(optimizer_name)
     with pytest.raises(ValueError):
-        optimizer = load_optimizer(optimizer_names)
         optimizer(None, momentum=-1e-3)
 
 
-@pytest.mark.parametrize('optimizer_names', ['ranger'])
-def test_lookahead_k(optimizer_names):
+@pytest.mark.parametrize('optimizer_name', ['ranger'])
+def test_lookahead_k(optimizer_name):
+    optimizer = load_optimizer(optimizer_name)
     with pytest.raises(ValueError):
-        optimizer = load_optimizer(optimizer_names)
         optimizer(None, k=-1)
 
 
-@pytest.mark.parametrize('optimizer_names', ['ranger21'])
-def test_beta0(optimizer_names):
-    optimizer = load_optimizer(optimizer_names)
-
+@pytest.mark.parametrize('optimizer_name', ['ranger21'])
+def test_beta0(optimizer_name):
+    optimizer = load_optimizer(optimizer_name)
     with pytest.raises(ValueError):
         optimizer(None, num_iterations=200, beta0=-0.1)
 
 
 @pytest.mark.parametrize('optimizer_names', ['nero'])
-def test_beta(optimizer_names):
-    optimizer = load_optimizer(optimizer_names)
-
+def test_beta(optimizer_name):
+    optimizer = load_optimizer(optimizer_name)
     with pytest.raises(ValueError):
         optimizer(None, beta=-0.1)
 
 
-@pytest.mark.parametrize('optimizer_names', BETA_OPTIMIZER_NAMES)
-def test_betas(optimizer_names):
-    optimizer = load_optimizer(optimizer_names)
+@pytest.mark.parametrize('optimizer_name', BETA_OPTIMIZER_NAMES)
+def test_betas(optimizer_name):
+    optimizer = load_optimizer(optimizer_name)
 
     with pytest.raises(ValueError):
         optimizer(None, betas=(-0.1, 0.1))
@@ -115,13 +125,12 @@ def test_betas(optimizer_names):
     with pytest.raises(ValueError):
         optimizer(None, betas=(0.1, -0.1))
 
-    if optimizer_names == 'adapnm':
+    if optimizer_name == 'adapnm':
         with pytest.raises(ValueError):
             optimizer(None, betas=(0.1, 0.1, -0.1))
 
 
-@pytest.mark.parametrize('optimizer_names', ['pcgrad'])
-def test_reduction(optimizer_names):
+def test_reduction():
     model: nn.Module = Example()
     parameters = model.parameters()
     optimizer = load_optimizer('adamp')(parameters)
@@ -130,10 +139,11 @@ def test_reduction(optimizer_names):
         PCGrad(optimizer, reduction='wrong')
 
 
-@pytest.mark.parametrize('optimizer_names', ['shampoo'])
-def test_update_frequency(optimizer_names):
+@pytest.mark.parametrize('optimizer_name', ['shampoo'])
+def test_update_frequency(optimizer_name):
+    optimizer = load_optimizer(optimizer_name)
     with pytest.raises(ValueError):
-        load_optimizer(optimizer_names)(None, update_freq=0)
+        optimizer(None, update_freq=0)
 
 
 def test_sam_parameters():

--- a/tests/test_optimizer_parameters.py
+++ b/tests/test_optimizer_parameters.py
@@ -108,7 +108,7 @@ def test_beta0(optimizer_name):
         optimizer(None, num_iterations=200, beta0=-0.1)
 
 
-@pytest.mark.parametrize('optimizer_names', ['nero'])
+@pytest.mark.parametrize('optimizer_name', ['nero'])
 def test_beta(optimizer_name):
     optimizer = load_optimizer(optimizer_name)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Problem (Why?)

https://github.com/kozistr/pytorch_optimizer/issues/62

`num_iterations` parameter at `Ranger21` needs a valid integer value, but None. So, it causes a type error when calculating warm-up iterations.

## Solution (What/How?)

* Not to assign a default value (None) to `num_iterations` parameter

## Other changes (bug fixes, small refactors)

nope

## Notes

version to 1.1.2