### PR TITLE
[Feature] support torch.hub.load

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -1,0 +1,10 @@
+dependencies = ["torch"]
+
+from functools import partial
+
+from pytorch_optimizer import get_supported_optimizers, load_optimizer
+
+for optimizer in get_supported_optimizers():
+    name = optimizer.__name__
+    for n in (name, name.lower()):
+        globals()[n] = partial(load_optimizer, optimizer=n)

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,10 +1,15 @@
 dependencies = ["torch"]
 
-from functools import partial
+from functools import partial as _partial, update_wrapper as _update_wrapper
 
-from pytorch_optimizer import get_supported_optimizers, load_optimizer
+from pytorch_optimizer import (
+    get_supported_optimizers as _get_supported_optimizers,
+    load_optimizer as _load_optimizer,
+)
 
-for optimizer in get_supported_optimizers():
+for optimizer in _get_supported_optimizers():
     name = optimizer.__name__
     for n in (name, name.lower()):
-        globals()[n] = partial(load_optimizer, optimizer=n)
+        func = _partial(_load_optimizer, optimizer=n)
+        _update_wrapper(func, optimizer)
+        globals()[n] = func

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,4 +1,4 @@
-dependencies = ["torch"]
+dependencies = ['torch']
 
 from functools import partial as _partial, update_wrapper as _update_wrapper
 

--- a/pytorch_optimizer/__init__.py
+++ b/pytorch_optimizer/__init__.py
@@ -1,5 +1,7 @@
 # pylint: disable=unused-import
-from typing import Callable, Dict, List
+from typing import Dict, List, Type
+
+from torch.optim import Optimizer
 
 from pytorch_optimizer.adabelief import AdaBelief
 from pytorch_optimizer.adabound import AdaBound
@@ -54,10 +56,10 @@ OPTIMIZER_LIST: List = [
     SGDP,
     Shampoo,
 ]
-OPTIMIZERS: Dict[str, Callable] = {str(optimizer.__name__).lower(): optimizer for optimizer in OPTIMIZER_LIST}
+OPTIMIZERS: Dict[str, Type[Optimizer]] = {str(optimizer.__name__).lower(): optimizer for optimizer in OPTIMIZER_LIST}
 
 
-def load_optimizer(optimizer: str) -> Callable:
+def load_optimizer(optimizer: str) -> Type[Optimizer]:
     optimizer: str = optimizer.lower()
 
     if optimizer not in OPTIMIZERS:
@@ -66,5 +68,5 @@ def load_optimizer(optimizer: str) -> Callable:
     return OPTIMIZERS[optimizer]
 
 
-def get_supported_optimizers() -> List:
+def get_supported_optimizers() -> List[Type[Optimizer]]:
     return OPTIMIZER_LIST


### PR DESCRIPTION
## Problem (Why?)

loading optimizers via [`torch.hub.load`](https://pytorch.org/docs/stable/hub.html)

## Solution (What/How?)

it is inconvenient to define functions one by one, I used a trick using `globals()`.

## Other changes (bug fixes, small refactors)

Change `Callable` to `Type[Optimizer]`. Perhaps this is what you intended. see: [typing.Type](https://docs.python.org/ko/3/library/typing.html#typing.Type)

## Notes

[example colab](https://colab.research.google.com/drive/1Hc4axLTiNJVwwg8bcyCI-Ti-CUzsA1xR?usp=sharing)

```python
import torch

Adan = torch.hub.load("Bing-su/pytorch_optimizer:hubconf", "Adan")
```
