### PR TITLE
[Docs] fix `raw` derive in RST file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,6 +228,17 @@ Gradient Surgery for Multi-Task Learning
 Citations
 ---------
 
+[AdamP]_
+
+.. [Adamp] AdamP: Slowing Down the Slowdown for Momentum Optimizers on Scale-invariant Weights
+
+    @inproceedings{heo2021adamp,
+        title={AdamP: Slowing Down the Slowdown for Momentum Optimizers on Scale-invariant Weights},
+        author={Heo, Byeongho and Chun, Sanghyuk and Oh, Seong Joon and Han, Dongyoon and Yun, Sangdoo and Kim, Gyuwan and Uh, Youngjung and Ha, Jung-Woo},
+        year={2021},
+        booktitle={International Conference on Learning Representations (ICLR)},
+    }
+
 .. raw:: html
 
    <details>

--- a/README.rst
+++ b/README.rst
@@ -230,248 +230,36 @@ Citations
 
 `AdamP <https://scholar.googleusercontent.com/scholar.bib?q=info:SfSq5UFS71wJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YevydU:AAGBfm0AAAAAYxCp0dVqrS10vvLfEDcY31SdH8ZRpeB4&scisig=AAGBfm0AAAAAYxCp0bLEn4nNd2Gmpb64J-nsN62Hq19N&scisf=4&ct=citation&cd=-1&hl=en>`__
 
+`Adaptive Gradient Clipping (AGC) <https://scholar.googleusercontent.com/scholar.bib?q=info:G6OwKvfrhU4J:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YesC_0:AAGBfm0AAAAAYxCqE_3u1oAcHorMaAJ_SR7Xo5PvdxIC&scisig=AAGBfm0AAAAAYxCqEz7D8y15Q5sJL5QUdbpTMdFHGSMi&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-.. [AGC]
+`Chebyshev LR Schedules <https://scholar.googleusercontent.com/scholar.bib?q=info:5bxSTRao5pUJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YesV7g:AAGBfm0AAAAAYxCqT7jEP6cOz39vHjSXD71OiD_WHNeu&scisig=AAGBfm0AAAAAYxCqTxBAT7yBvhGW1KZopv6tYDL6fjhq&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-    @article{brock2021high,
-        author={Andrew Brock and Soham De and Samuel L. Smith and Karen Simonyan},
-        title={High-Performance Large-Scale Image Recognition Without Normalization},
-        journal={arXiv preprint arXiv:2102.06171},
-        year={2021}
-    }
+`Gradient Centralization (GC) <https://scholar.googleusercontent.com/scholar.bib?q=info:MQDRtwz4RekJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YeskLw:AAGBfm0AAAAAYxCqiLx6z7Lo-Fag54T6c22UyMxC3uKU&scisig=AAGBfm0AAAAAYxCqiDzweYqjl8tPPjAVYv4y42-amW04&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-.. [Chebyshev-LR-Schedules]
+`Lookahead <https://scholar.googleusercontent.com/scholar.bib?q=info:A1J2Cn9LEyQJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0Yest68:AAGBfm0AAAAAYxCqr68LW2mC6SXXXXIEv17IH1VfVwTU&scisig=AAGBfm0AAAAAYxCqr0ZQGEPcASa4BcFlRIMYfC_ELoH3&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-    @article{agarwal2021acceleration,
-        title={Acceleration via Fractal Learning Rate Schedules},
-        author={Agarwal, Naman and Goel, Surbhi and Zhang, Cyril},
-        journal={arXiv preprint arXiv:2103.01338},
-        year={2021}
-    }
+`RAdam <https://scholar.googleusercontent.com/scholar.bib?q=info:tTLLKZi0NB4J:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0Yes-Kc:AAGBfm0AAAAAYxCq4KdbtBaCrCnPM3teTRbkG2ke4zu1&scisig=AAGBfm0AAAAAYxCq4DKANM54ZoMqj8sYTKjhrrWTYZJv&scisf=4&ct=citation&cd=-1&hl=en>`__
 
+`Norm Loss <https://scholar.googleusercontent.com/scholar.bib?q=info:cgudi9fC610J:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YetGG8:AAGBfm0AAAAAYxCrAG8mPyX5faDy-Orn0sNT3laCqhCX&scisig=AAGBfm0AAAAAYxCrAPhudmT6SGj0XyHAGuBIgn4iP9UM&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-.. raw:: html
+`Positive-Negative Momentum <https://scholar.googleusercontent.com/scholar.bib?q=info:EU4LbWCU44UJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YetNIE:AAGBfm0AAAAAYxCrLIFD4YhCP2b755xkmgM9ekT5z2I3&scisig=AAGBfm0AAAAAYxCrLA0s6cI4xGBVGFOpGDBJkD4jW45M&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-   </details>
+`Explore-Exploit Learning Rate Schedule <https://scholar.googleusercontent.com/scholar.bib?q=info:-Z0_Ot7wtzsJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YetRPU:AAGBfm0AAAAAYxCrXPVjSJKqfwDN1V1KDkX--4xZuQ3d&scisig=AAGBfm0AAAAAYxCrXLMftLTqnC4BUjTH8TEDoeg8Xn0P&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-.. raw:: html
+`On the adequacy of untuned warmup for adaptive optimization <https://scholar.googleusercontent.com/scholar.bib?q=info:_xl7KQ5GS8wJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0Yetb_s:AAGBfm0AAAAAYxCrd_t2aLAHKkunOI588UJkaMygzX7V&scisig=AAGBfm0AAAAAYxCrd4xDt7wmBQYV2J88Dv1klVIEEldW&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-   <details>
-   <summary><a>Chebyshev LR Schedules: Acceleration via Fractal Learning Rate Schedules</a></summary>
+`Stable weight decay regularization <https://scholar.googleusercontent.com/scholar.bib?q=info:braJqOHCLpcJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0Yetu34:AAGBfm0AAAAAYxCro36JSgGOwWVwx8K21_sJaiJCi_tc&scisig=AAGBfm0AAAAAYxCro42f96rMxskixD8vZdyLuRCv9hzp&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-::
+`Softplus transformation <https://scholar.googleusercontent.com/scholar.bib?q=info:_V_Tt16gXUsJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0Yet3gY:AAGBfm0AAAAAYxCrxgbrSUaRQqStYNBuVBPS3TMRgH7f&scisig=AAGBfm0AAAAAYxCrxqnu8UQn70pqZWxbBoJaz05eCgsj&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-    @article{agarwal2021acceleration,
-        title={Acceleration via Fractal Learning Rate Schedules},
-        author={Agarwal, Naman and Goel, Surbhi and Zhang, Cyril},
-        journal={arXiv preprint arXiv:2103.01338},
-        year={2021}
-    }
+`MADGRAD <https://scholar.googleusercontent.com/scholar.bib?q=info:WnYNAExj8yEJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0Yet6g8:AAGBfm0AAAAAYxCr8g-OAPHACQZtBVamCAXY3mUPO7qR&scisig=AAGBfm0AAAAAYxCr8iVTWljaTOsxZ9ZHce61Uh5rYWdB&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-.. raw:: html
+`AdaHessian <https://scholar.googleusercontent.com/scholar.bib?q=info:NVTf2oQp6YoJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YeqDj8:AAGBfm0AAAAAYxCsFj89NAaxz72Tc2BaFva6FGFHuzjO&scisig=AAGBfm0AAAAAYxCsFm7SeFVY6NaIy5w0BOLAVGM4oy-z&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-   </details>
+` <>`__
 
-.. raw:: html
+` <>`__
 
-   <details>
-   <summary><a>Gradient Centralization (GC)</a></summary>
-
-::
-
-    @inproceedings{yong2020gradient,
-        title={Gradient centralization: A new optimization technique for deep neural networks},
-        author={Yong, Hongwei and Huang, Jianqiang and Hua, Xiansheng and Zhang, Lei},
-        booktitle={European Conference on Computer Vision},
-        pages={635--652},
-        year={2020},
-        organization={Springer}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>Lookahead: k steps forward, 1 step back</a></summary>
-
-::
-
-    @article{zhang2019lookahead,
-        title={Lookahead optimizer: k steps forward, 1 step back},
-        author={Zhang, Michael R and Lucas, James and Hinton, Geoffrey and Ba, Jimmy},
-        journal={arXiv preprint arXiv:1907.08610},
-        year={2019}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>RAdam: On the Variance of the Adaptive Learning Rate and Beyond</a></summary>
-
-::
-
-    @inproceedings{liu2019radam,
-        author = {Liu, Liyuan and Jiang, Haoming and He, Pengcheng and Chen, Weizhu and Liu, Xiaodong and Gao, Jianfeng and Han, Jiawei},
-        booktitle = {Proceedings of the Eighth International Conference on Learning Representations (ICLR 2020)},
-        month = {April},
-        title = {On the Variance of the Adaptive Learning Rate and Beyond},
-        year = {2020}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>Norm Loss: An efficient yet effective regularization method for deep neural networks</a></summary>
-
-::
-
-    @inproceedings{georgiou2021norm,
-        title={Norm Loss: An efficient yet effective regularization method for deep neural networks},
-        author={Georgiou, Theodoros and Schmitt, Sebastian and B{\"a}ck, Thomas and Chen, Wei and Lew, Michael},
-        booktitle={2020 25th International Conference on Pattern Recognition (ICPR)},
-        pages={8812--8818},
-        year={2021},
-        organization={IEEE}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>Positive-Negative Momentum: Manipulating Stochastic Gradient Noise to Improve Generalization</a></summary>
-
-::
-
-    @article{xie2021positive,
-        title={Positive-Negative Momentum: Manipulating Stochastic Gradient Noise to Improve Generalization},
-        author={Xie, Zeke and Yuan, Li and Zhu, Zhanxing and Sugiyama, Masashi},
-        journal={arXiv preprint arXiv:2103.17182},
-        year={2021}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>Wide-minima Density Hypothesis and the Explore-Exploit Learning Rate Schedule</a></summary>
-
-::
-
-    @article{iyer2020wide,
-        title={Wide-minima Density Hypothesis and the Explore-Exploit Learning Rate Schedule},
-        author={Iyer, Nikhil and Thejas, V and Kwatra, Nipun and Ramjee, Ramachandran and Sivathanu, Muthian},
-        journal={arXiv preprint arXiv:2003.03977},
-        year={2020}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>On the adequacy of untuned warmup for adaptive optimization</a></summary>
-
-::
-
-    @article{ma2019adequacy,
-        title={On the adequacy of untuned warmup for adaptive optimization},
-        author={Ma, Jerry and Yarats, Denis},
-        journal={arXiv preprint arXiv:1910.04209},
-        volume={7},
-        year={2019}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>Stable weight decay regularization</a></summary>
-
-::
-
-    @article{xie2020stable,
-        title={Stable weight decay regularization},
-        author={Xie, Zeke and Sato, Issei and Sugiyama, Masashi},
-        journal={arXiv preprint arXiv:2011.11152},
-        year={2020}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>Softplus transformation</a></summary>
-
-::
-
-    @article{tong2019calibrating,
-        title={Calibrating the adaptive learning rate to improve convergence of adam},
-        author={Tong, Qianqian and Liang, Guannan and Bi, Jinbo},
-        journal={arXiv preprint arXiv:1908.00700},
-        year={2019}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>MADGRAD: a momentumized, adaptive, dual averaged gradient method for stochastic optimization</a></summary>
-
-::
-
-    @article{defazio2021adaptivity,
-        title={Adaptivity without compromise: a momentumized, adaptive, dual averaged gradient method for stochastic optimization},
-        author={Defazio, Aaron and Jelassi, Samy},
-        journal={arXiv preprint arXiv:2101.11075},
-        year={2021}
-    }
-
-.. raw:: html
-
-   </details>
-
-
-.. raw:: html
-
-   <details>
-   <summary><a>AdaHessian: An adaptive second order optimizer for machine learning</a></summary>
-
-::
-
-    @article{yao2020adahessian,
-        title={ADAHESSIAN: An adaptive second order optimizer for machine learning},
-        author={Yao, Zhewei and Gholami, Amir and Shen, Sheng and Mustafa, Mustafa and Keutzer, Kurt and Mahoney, Michael W},
-        journal={arXiv preprint arXiv:2006.00719},
-        year={2020}
-    }
 
 .. raw:: html
 

--- a/README.rst
+++ b/README.rst
@@ -230,7 +230,7 @@ Citations
 
 [AdamP]_
 
-.. [Adamp] AdamP: Slowing Down the Slowdown for Momentum Optimizers on Scale-invariant Weights
+.. [Adamp]
 
     @inproceedings{heo2021adamp,
         title={AdamP: Slowing Down the Slowdown for Momentum Optimizers on Scale-invariant Weights},

--- a/README.rst
+++ b/README.rst
@@ -256,229 +256,27 @@ Citations
 
 `AdaHessian <https://scholar.googleusercontent.com/scholar.bib?q=info:NVTf2oQp6YoJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YeqDj8:AAGBfm0AAAAAYxCsFj89NAaxz72Tc2BaFva6FGFHuzjO&scisig=AAGBfm0AAAAAYxCsFm7SeFVY6NaIy5w0BOLAVGM4oy-z&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-` <>`__
+`AdaBound <https://scholar.googleusercontent.com/scholar.bib?q=info:CsrDHbimhWgJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YeqXZQ:AAGBfm0AAAAAYxCsRZR-WfagzOhOzHZ3ARAlehesAaQL&scisig=AAGBfm0AAAAAYxCsRSRkCJhTl9QisH1o5k8cbHBOOaQ0&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-` <>`__
+`Adabelief <https://scholar.googleusercontent.com/scholar.bib?q=info:cf1gkNMQCAsJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YeqcPk:AAGBfm0AAAAAYxCsaPn6O2pgnuIZmWlssnrLY7Zug1ab&scisig=AAGBfm0AAAAAYxCsaPiac1Ktzqa7-8wabbO3pQzq2ezC&scisf=4&ct=citation&cd=-1&hl=en>`__
 
+`Sharpness-aware minimization <https://scholar.googleusercontent.com/scholar.bib?q=info:621rS0TnyooJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YeqkcY:AAGBfm0AAAAAYxCsicYP7tw5aRNOjjXwkA4Vow-7jzWX&scisig=AAGBfm0AAAAAYxCsibGf462P1_gsWErL-yeGdIeNHywO&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-.. raw:: html
+`Adaptive Sharpness-aware minimization <https://scholar.googleusercontent.com/scholar.bib?q=info:ta4j_XtLqXYJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YeqhhE:AAGBfm0AAAAAYxCsnhEGLjlU7PCikAYnM6LYuACuKcfu&scisig=AAGBfm0AAAAAYxCsno-VG_RWK0tOtqZdWxel6qTKtNyC&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-   </details>
+`diffGrad <https://scholar.googleusercontent.com/scholar.bib?q=info:yGmD33AMjN4J:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0Yeqp7I:AAGBfm0AAAAAYxCsv7IYbE3ozFQrbhjAxbBdhbcNrNaT&scisig=AAGBfm0AAAAAYxCsv2mDmsNyW0R1koLK3vG04K7HEyRW&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-.. raw:: html
+`On the Convergence of Adam and Beyond <https://scholar.googleusercontent.com/scholar.bib?q=info:B0s07Z6wFWkJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0Yeq5VI:AAGBfm0AAAAAYxCs_VIET-w3Fc6Bx3B7pbnercaue84a&scisig=AAGBfm0AAAAAYxCs_Rzcu3G4tmMrxOdaeXsfN9RSp3aA&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-   <details>
-   <summary><a>AdaBound: Adaptive Gradient Methods with Dynamic Bound of Learning Rate</a></summary>
+`Gradient surgery for multi-task learning <https://scholar.googleusercontent.com/scholar.bib?q=info:ae9CdgI_CtkJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YerBWY:AAGBfm0AAAAAYxCtHWZzzktUQ2GRhrSx_LWh7AiWbeUV&scisig=AAGBfm0AAAAAYxCtHaXMBqe9K0CCS9McXDPM8BRHHrTD&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-::
+`AdamD <https://scholar.googleusercontent.com/scholar.bib?q=info:XimgvO50x1AJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YerIAo:AAGBfm0AAAAAYxCtOAq69M6dSH0RQEVyiQYk-5ToDCvA&scisig=AAGBfm0AAAAAYxCtOJRDGw1cq6WRv2NODkLE5sgxAPz-&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-    @inproceedings{Luo2019AdaBound,
-        author = {Luo, Liangchen and Xiong, Yuanhao and Liu, Yan and Sun, Xu},
-        title = {Adaptive Gradient Methods with Dynamic Bound of Learning Rate},
-        booktitle = {Proceedings of the 7th International Conference on Learning Representations},
-        month = {May},
-        year = {2019},
-        address = {New Orleans, Louisiana}
-    }
+`Shampoo <https://scholar.googleusercontent.com/scholar.bib?q=info:GQn55DATO9sJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YerS64:AAGBfm0AAAAAYxCtU65eO2d2kyAf36X-vcVbovISPAY9&scisig=AAGBfm0AAAAAYxCtUwoUqdIzjjuqat7lPKZylm3bO6io&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-.. raw:: html
+`Nero <https://scholar.googleusercontent.com/scholar.bib?q=info:X7-f1Z-47X8J:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0Yercz8:AAGBfm0AAAAAYxCtaz9tFLHi82julKp6XCCGPZLRN2Qt&scisig=AAGBfm0AAAAAYxCta7MAiMjXj8qzcM8XBLi2AxsgVHIB&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>AdaBelief: Adapting stepsizes by the belief in observed gradients</a></summary>
-
-::
-
-    @article{zhuang2020adabelief,
-        title={Adabelief optimizer: Adapting stepsizes by the belief in observed gradients},
-        author={Zhuang, Juntang and Tang, Tommy and Ding, Yifan and Tatikonda, Sekhar and Dvornek, Nicha and Papademetris, Xenophon and Duncan, James S},
-        journal={arXiv preprint arXiv:2010.07468},
-        year={2020}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>Sharpness-Aware Minimization</a></summary>
-
-::
-
-    @article{foret2020sharpness,
-        title={Sharpness-aware minimization for efficiently improving generalization},
-        author={Foret, Pierre and Kleiner, Ariel and Mobahi, Hossein and Neyshabur, Behnam},
-        journal={arXiv preprint arXiv:2010.01412},
-        year={2020}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>Adaptive Sharpness-Aware Minimization</a></summary>
-
-::
-
-    @article{kwon2021asam,
-        title={ASAM: Adaptive Sharpness-Aware Minimization for Scale-Invariant Learning of Deep Neural Networks},
-        author={Kwon, Jungmin and Kim, Jeongseop and Park, Hyunseo and Choi, In Kwon},
-        journal={arXiv preprint arXiv:2102.11600},
-        year={2021}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>diffGrad: An optimization method for convolutional neural networks</a></summary>
-
-::
-
-    @article{dubey2019diffgrad,
-        title={diffgrad: An optimization method for convolutional neural networks},
-        author={Dubey, Shiv Ram and Chakraborty, Soumendu and Roy, Swalpa Kumar and Mukherjee, Snehasis and Singh, Satish Kumar and Chaudhuri, Bidyut Baran},
-        journal={IEEE transactions on neural networks and learning systems},
-        volume={31},
-        number={11},
-        pages={4500--4511},
-        year={2019},
-        publisher={IEEE}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>On the Convergence of Adam and Beyond</a></summary>
-
-::
-
-    @article{reddi2019convergence,
-        title={On the convergence of adam and beyond},
-        author={Reddi, Sashank J and Kale, Satyen and Kumar, Sanjiv},
-        journal={arXiv preprint arXiv:1904.09237},
-        year={2019}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>Gradient Surgery for Multi-Task Learning</a></summary>
-
-::
-
-    @article{yu2020gradient,
-        title={Gradient surgery for multi-task learning},
-        author={Yu, Tianhe and Kumar, Saurabh and Gupta, Abhishek and Levine, Sergey and Hausman, Karol and Finn, Chelsea},
-        journal={arXiv preprint arXiv:2001.06782},
-        year={2020}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>AdamD: Improved bias-correction in Adam</a></summary>
-
-::
-
-    @article{john2021adamd,
-        title={AdamD: Improved bias-correction in Adam},
-        author={John, John St},
-        journal={arXiv preprint arXiv:2110.10828},
-        year={2021}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>Shampoo: Preconditioned Stochastic Tensor Optimization</a></summary>
-
-::
-
-    @inproceedings{gupta2018shampoo,
-        title={Shampoo: Preconditioned stochastic tensor optimization},
-        author={Gupta, Vineet and Koren, Tomer and Singer, Yoram},
-        booktitle={International Conference on Machine Learning},
-        pages={1842--1850},
-        year={2018},
-        organization={PMLR}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>Nero: Learning by Turning: Neural Architecture Aware Optimisation</a></summary>
-
-::
-
-    @misc{nero2021,
-        title={Learning by Turning: Neural Architecture Aware Optimisation},
-        author={Yang Liu and Jeremy Bernstein and Markus Meister and Yisong Yue},
-        year={2021},
-        eprint={arXiv:2102.07227}
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>Adan: Adaptive Nesterov Momentum Algorithm for Faster Optimizing Deep Models</a></summary>
-
-::
-
-    @ARTICLE{2022arXiv220806677X,
-        author = {{Xie}, Xingyu and {Zhou}, Pan and {Li}, Huan and {Lin}, Zhouchen and {Yan}, Shuicheng},
-        title = "{Adan: Adaptive Nesterov Momentum Algorithm for Faster Optimizing Deep Models}",
-        journal = {arXiv e-prints},
-        keywords = {Computer Science - Machine Learning, Mathematics - Optimization and Control},
-        year = 2022,
-        month = aug,
-        eid = {arXiv:2208.06677},
-        pages = {arXiv:2208.06677},
-        archivePrefix = {arXiv},
-        eprint = {2208.06677},
-        primaryClass = {cs.LG},
-        adsurl = {https://ui.adsabs.harvard.edu/abs/2022arXiv220806677X},
-        adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-    }
-
-.. raw:: html
-
-   </details>
+`Adan <https://scholar.googleusercontent.com/scholar.bib?q=info:rMUXKCk35EAJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YerkVs:AAGBfm0AAAAAYxCtiVs7M7Oh9VkEVan-wY3IXOKyQtx1&scisig=AAGBfm0AAAAAYxCtiYyoEigNiau7MNmGcvqAEC8nSm-L&scisf=4&ct=citation&cd=-1&hl=en>`__
 
 Author
 ------

--- a/README.rst
+++ b/README.rst
@@ -228,41 +228,10 @@ Gradient Surgery for Multi-Task Learning
 Citations
 ---------
 
-[AdamP]_
+`AdamP <https://scholar.googleusercontent.com/scholar.bib?q=info:SfSq5UFS71wJ:scholar.google.com/&output=citation&scisdr=CgX1Wk9EELXN0YevydU:AAGBfm0AAAAAYxCp0dVqrS10vvLfEDcY31SdH8ZRpeB4&scisig=AAGBfm0AAAAAYxCp0bLEn4nNd2Gmpb64J-nsN62Hq19N&scisf=4&ct=citation&cd=-1&hl=en>`__
 
-.. [Adamp]
 
-    @inproceedings{heo2021adamp,
-        title={AdamP: Slowing Down the Slowdown for Momentum Optimizers on Scale-invariant Weights},
-        author={Heo, Byeongho and Chun, Sanghyuk and Oh, Seong Joon and Han, Dongyoon and Yun, Sangdoo and Kim, Gyuwan and Uh, Youngjung and Ha, Jung-Woo},
-        year={2021},
-        booktitle={International Conference on Learning Representations (ICLR)},
-    }
-
-.. raw:: html
-
-   <details>
-   <summary><a>AdamP: Slowing Down the Slowdown for Momentum Optimizers on Scale-invariant Weights</a></summary>
-
-::
-
-    @inproceedings{heo2021adamp,
-        title={AdamP: Slowing Down the Slowdown for Momentum Optimizers on Scale-invariant Weights},
-        author={Heo, Byeongho and Chun, Sanghyuk and Oh, Seong Joon and Han, Dongyoon and Yun, Sangdoo and Kim, Gyuwan and Uh, Youngjung and Ha, Jung-Woo},
-        year={2021},
-        booktitle={International Conference on Learning Representations (ICLR)},
-    }
-
-.. raw:: html
-
-   </details>
-
-.. raw:: html
-
-   <details>
-   <summary><a>Adaptive Gradient Clipping (AGC)</a></summary>
-
-::
+.. [AGC]
 
     @article{brock2021high,
         author={Andrew Brock and Soham De and Samuel L. Smith and Karen Simonyan},
@@ -270,6 +239,16 @@ Citations
         journal={arXiv preprint arXiv:2102.06171},
         year={2021}
     }
+
+.. [Chebyshev-LR-Schedules]
+
+    @article{agarwal2021acceleration,
+        title={Acceleration via Fractal Learning Rate Schedules},
+        author={Agarwal, Naman and Goel, Surbhi and Zhang, Cyril},
+        journal={arXiv preprint arXiv:2103.01338},
+        year={2021}
+    }
+
 
 .. raw:: html
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytorch_optimizer"
-version = "1.3.0"
+version = "1.3.1"
 description = "Bunch of optimizer implementations in PyTorch with clean-code, strict types. Also, including useful optimization ideas."
 license = "Apache-2.0"
 authors = ["kozistr <kozistr@gmail.com>"]


### PR DESCRIPTION
## Problem (Why?)

`raw` derive cannot be used due to the security issue e.g. code injection. so building pip package is failed.

## Solution (What/How?)

- [x] replace all `raw` derives to link

## Other changes (bug fixes, small refactors)

nope

## Notes

version to 1.3.1