### PR TITLE
[Feature, Fix] Adan optimizer 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytorch_optimizer"
-version = "1.3.1"
+version = "1.3.2"
 description = "Bunch of optimizer implementations in PyTorch with clean-code, strict types. Also, including useful optimization ideas."
 license = "Apache-2.0"
 authors = ["kozistr <kozistr@gmail.com>"]

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -164,6 +164,7 @@ def test_safe_f16_optimizers(optimizer_fp16_config):
         or (optimizer_name == 'RaLamb' and 'pre_norm' in config)
         or (optimizer_name == 'PNM')
         or (optimizer_name == 'Nero')
+        or (optimizer_name == 'Adan' and 'weight_decay' not in config)
     ):
         return True
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -80,7 +80,7 @@ OPTIMIZERS: List[Tuple[Any, Dict[str, Union[float, bool, int]], int]] = [
     (AdaPNM, {'lr': 3e-1, 'weight_decay': 1e-3, 'amsgrad': False}, 500),
     (Nero, {'lr': 5e-1}, 200),
     (Nero, {'lr': 5e-1, 'constraints': False}, 200),
-    (Adan, {'lr': 1e-1}, 300),
+    (Adan, {'lr': 5e-1}, 300),
     (Adan, {'lr': 1e-0, 'weight_decay': 1e-3, 'use_gc': True}, 300),
     (Adan, {'lr': 1e-0, 'weight_decay': 1e-3, 'use_gc': True, 'weight_decouple': True}, 300),
 ]

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -80,8 +80,9 @@ OPTIMIZERS: List[Tuple[Any, Dict[str, Union[float, bool, int]], int]] = [
     (AdaPNM, {'lr': 3e-1, 'weight_decay': 1e-3, 'amsgrad': False}, 500),
     (Nero, {'lr': 5e-1}, 200),
     (Nero, {'lr': 5e-1, 'constraints': False}, 200),
-    (Adan, {'lr': 2e-1}, 200),
-    (Adan, {'lr': 1e-0, 'weight_decay': 1e-3, 'use_gc': True}, 500),
+    (Adan, {'lr': 1e-1}, 300),
+    (Adan, {'lr': 1e-0, 'weight_decay': 1e-3, 'use_gc': True}, 300),
+    (Adan, {'lr': 1e-0, 'weight_decay': 1e-3, 'use_gc': True, 'weight_decouple': True}, 300),
 ]
 
 ADAMD_SUPPORTED_OPTIMIZERS: List[Tuple[Any, Dict[str, Union[float, bool, int]], int]] = [


### PR DESCRIPTION
## Problem (Why?)

forgot to divide into `beta_correation` wehn calculating `perturb`

## Solution (What/How?)

- [x] support `weight_decouple` feature, referred in the paper
- [x] fix by dividing with `beta_correction`

## Other changes (bug fixes, small refactors)

- [x] adjust Adan recipes for the test cases

## Notes

update version to `v1.3.2`