### PR TITLE
[Fix] update hubconf.py

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -7,14 +7,23 @@ Usage:
 from functools import partial as _partial
 from functools import update_wrapper as _update_wrapper
 
+from pytorch_optimizer import get_supported_lr_schedulers as _get_supported_lr_schedulers
 from pytorch_optimizer import get_supported_optimizers as _get_supported_optimizers
+from pytorch_optimizer import load_lr_scheduler as _load_lr_scheduler
 from pytorch_optimizer import load_optimizer as _load_optimizer
 
 dependencies = ['torch']
 
-for optimizer in _get_supported_optimizers():
-    name: str = optimizer.__name__
+for _optimizer in _get_supported_optimizers():
+    name: str = _optimizer.__name__
+    _func = _partial(_load_optimizer, optimizer=name)
+    _update_wrapper(_func, _optimizer)
     for n in (name, name.lower(), name.upper()):
-        func = _partial(_load_optimizer, optimizer=n)
-        _update_wrapper(func, optimizer)
-        globals()[n] = func
+        globals()[n] = _func
+
+for _scheduler in _get_supported_lr_schedulers():
+    name: str = _scheduler.__name__
+    _func = _partial(_load_lr_scheduler, lr_scheduler=name)
+    _update_wrapper(_func, _scheduler)
+    for n in (name, name.lower(), name.upper()):
+        globals()[n] = _func

--- a/hubconf.py
+++ b/hubconf.py
@@ -17,13 +17,13 @@ dependencies = ['torch']
 for _optimizer in _get_supported_optimizers():
     name: str = _optimizer.__name__
     _func = _partial(_load_optimizer, optimizer=name)
-    _update_wrapper(_func, _optimizer)
+    _update_wrapper(_func, _optimizer.__init__)
     for n in (name, name.lower(), name.upper()):
         globals()[n] = _func
 
 for _scheduler in _get_supported_lr_schedulers():
     name: str = _scheduler.__name__
     _func = _partial(_load_lr_scheduler, lr_scheduler=name)
-    _update_wrapper(_func, _scheduler)
+    _update_wrapper(_func, _scheduler.__init__)
     for n in (name, name.lower(), name.upper()):
         globals()[n] = _func


### PR DESCRIPTION
2.0.0 출시를 축하드립니다.

## Problem (Why?)

1. load schedulers

2. torch.hub.list에서 `func`, `optimizer` 감추기
```python
>>> import torch

>>> torch.hub.list("kozistr/pytorch_optimizer")
...
 'adan',
 'adapnm',
 'diffgrad',
 'diffrgrad',
 'func', # <<<<<<
 'lamb',
 'lars',
 'madgrad',
 'nero',
 'optimizer', # <<<<<<
 'pnm',
 'radam',
 'ralamb',
 'ranger',
 'ranger21',
 'sgdp',
 'shampoo']
```
3. torch.load.help 타겟을 class 자체에서 __init__으로 변경

- before

```python
>>> print(torch.hub.help("kozistr/pytorch_optimizer", "ranger"))

    Reference : https://github.com/lessw2020/Ranger-Deep-Learning-Optimizer
    Example :
        from pytorch_optimizer import Ranger
        ...
        model = YourModel()
        optimizer = Ranger(model.parameters())
        ...
        for input, output in data:
          optimizer.zero_grad()
          loss = loss_function(output, model(input))
          loss.backward()
          optimizer.step()
```

- after

```python
>>> print(torch.hub.help("Bing-su/pytorch_optimizer:hubconf", "ranger"))

Ranger optimizer
        :param params: PARAMETERS. iterable of parameters to optimize or dicts defining parameter groups
        :param lr: float. learning rate
        :param betas: BETAS. coefficients used for computing running averages of gradient and the squared hessian trace
        :param weight_decay: float. weight decay (L2 penalty)
        :param n_sma_threshold: int. (recommended is 5)
        :param use_gc: bool. use Gradient Centralization (both convolution & fc layers)
        :param gc_conv_only: bool. use Gradient Centralization (only convolution layer)
        :param adamd_debias_term: bool. Only correct the denominator to avoid inflating step sizes early in training
        :param eps: float. term added to the denominator to improve numerical stability
```


## Solution (What/How?)

거창한 설명에 비해 코드 수정을 별로 많지 않습니다. 아래 변경점을 확인해주세요.

## Notes

3번 help 타겟을 .__init__으로 변경한건 사람마다 생각이 다를 것 같네요...
