### PR TITLE
[Fix] Ranger21 not skipping update

### DIFF
--- a/pytorch_optimizer/optimizer/ranger21.py
+++ b/pytorch_optimizer/optimizer/ranger21.py
@@ -247,12 +247,11 @@ class Ranger21(Optimizer, BaseOptimizer):
 
         # Phase 2 - Apply weight decay and step
         for group in self.param_groups:
-            p = group['params'][0]
-            if p.grad is None:
+            if len(self.state) == 0:
                 continue
-
-            lr = group['lr']
-            step = self.state[group['params'][0]]['step']
+            p = next(iter(self.state.keys()))
+            lr = group["lr"]
+            step = self.state[p]["step"]
 
             beta1, beta2 = group['betas']
             bias_correction1 = 1.0 - beta1 ** step  # fmt: skip


### PR DESCRIPTION
## Problem (Why?)

Ranger21 does not go through the 2nd phase if the first parameter does not have a grad. This results in no training happing

## Solution (What/How?)

We should rather go to the parameter that has a grad which is simply taking the first of the state dict.