### PR TITLE
[Fix] Make Lookahead a subclass of Optimizer

### DIFF
--- a/pytorch_optimizer/optimizer/lookahead.py
+++ b/pytorch_optimizer/optimizer/lookahead.py
@@ -2,12 +2,13 @@ from collections import defaultdict
 from typing import Dict
 
 import torch
+from torch.optim import Optimizer
 
 from pytorch_optimizer.base.optimizer import BaseOptimizer
-from pytorch_optimizer.base.types import CLOSURE, LOSS, OPTIMIZER, STATE
+from pytorch_optimizer.base.types import CLOSURE, LOSS, OPTIMIZER, STATE, DEFAULTS
 
 
-class Lookahead(BaseOptimizer):
+class Lookahead(BaseOptimizer, Optimizer):
     r"""k steps forward, 1 step back.
 
     :param optimizer: OPTIMIZER. base optimizer.
@@ -32,7 +33,10 @@ class Lookahead(BaseOptimizer):
         self.pullback_momentum = pullback_momentum
 
         self.optimizer = optimizer
-        self.param_groups = self.optimizer.param_groups
+
+        defaults: DEFAULTS = dict()
+        super().__init__(optimizer.param_groups, defaults)
+
         self.state: STATE = defaultdict(dict)
 
         for group in self.param_groups:
@@ -45,6 +49,7 @@ class Lookahead(BaseOptimizer):
                 state['slow_params'].copy_(p)
                 if self.pullback_momentum == 'pullback':
                     state['slow_momentum'] = torch.zeros_like(p)
+        
 
     def __getstate__(self):
         return {


### PR DESCRIPTION
## Problem (Why?)

The problem is described in #200. In short, `Lookahead` needs to be a subclass of `torch.optim.Optimizer` in order to work with PyTorch Lightning.

## Solution (What/How?)

Added `torch.optim.Optimizer` as a superclass to `Lookahead`.

## Other changes (bug fixes, small refactors)

We don't need the line `self.param_groups = self.optimizer.param_groups` as that is done inside `torch.optim.Optimizer.__init__`.

## Notes

N/A