### PR TITLE
[Bugfix] Fix SRMM to allow operation beyond memory_length

### DIFF
--- a/pytorch_optimizer/optimizer/srmm.py
+++ b/pytorch_optimizer/optimizer/srmm.py
@@ -53,7 +53,7 @@ class SRMM(Optimizer, BaseOptimizer):
                 group['step'] = 1
 
             w_t: float = (
-                (group['step'] + 1) % (group['memory_length'] if group['memory_length'] is not None else 1)
+                (group['step'] % (group['memory_length'] if group['memory_length'] is not None else 1)) + 1
             ) ** -group['beta']
 
             for p in group['params']:


### PR DESCRIPTION
## Problem (Why?)
At step `memeory_length+1` it causes a `0**-beta` which is not allowed.

## Solution (What/How?)

Move the `+1` to outside the mod expression

## Other changes (bug fixes, small refactors)

no

## Notes

 I think this was just a logic error but let me know if I'm incorrect since I'm not investigating this specific optimizer; I'm working on test harness to compare all optimizers.
