### PR TITLE
[Fix] Implement better `wd_ban_list` handling

### DIFF
--- a/pytorch_optimizer/optimizer/utils.py
+++ b/pytorch_optimizer/optimizer/utils.py
@@ -198,21 +198,20 @@ def get_optimizer_parameters(
     weight_decay: float,
     wd_ban_list: List[str] = ('bias', 'LayerNorm.bias', 'LayerNorm.weight'),
 ) -> PARAMETERS:
-    r"""Get optimizer parameters while filtering specified modules.
-
+    r"""
+    Get optimizer parameters while filtering specified modules.
     :param model_or_parameter: Union[nn.Module, List]. model or parameters.
     :param weight_decay: float. weight_decay.
     :param wd_ban_list: List[str]. ban list not to set weight decay.
     :returns: PARAMETERS. new parameter list.
     """
     
+
     fully_qualified_names = []
     for module_name, module in model_or_parameter.named_modules():
-        for param_name, param in module.named_parameters(recurse=False):
+        for param_name, _param in module.named_parameters(recurse=False):
             # Full parameter name includes module and parameter names
-            full_param_name = (
-                f"{module_name}.{param_name}" if module_name else param_name
-            )
+            full_param_name = f'{module_name}.{param_name}' if module_name else param_name
             # Check if any ban list substring is in the parameter name or module name
             if (
                 any(banned in param_name for banned in wd_ban_list)
@@ -223,14 +222,20 @@ def get_optimizer_parameters(
 
     if isinstance(model_or_parameter, nn.Module):
         model_or_parameter = list(model_or_parameter.named_parameters())
-    
+
     return [
         {
-            'params': [p for n, p in model_or_parameter if p.requires_grad and not any(nd in n for nd in fully_qualified_names)],
+            'params': [
+                p
+                for n, p in model_or_parameter
+                if p.requires_grad and not any(nd in n for nd in fully_qualified_names)
+            ],
             'weight_decay': weight_decay,
         },
         {
-            'params': [p for n, p in model_or_parameter if p.requires_grad and any(nd in n for nd in fully_qualified_names)],
+            'params': [
+                p for n, p in model_or_parameter if p.requires_grad and any(nd in n for nd in fully_qualified_names)
+            ],
             'weight_decay': 0.0,
         },
     ]

--- a/pytorch_optimizer/optimizer/utils.py
+++ b/pytorch_optimizer/optimizer/utils.py
@@ -205,16 +205,41 @@ def get_optimizer_parameters(
     :param wd_ban_list: List[str]. ban list not to set weight decay.
     :returns: PARAMETERS. new parameter list.
     """
+    
+    def find_fully_qualified_names(
+        model: nn.Module,
+        wd_ban_list: List[str] = ("bias", "LayerNorm.weight", "LayerNorm.bias"),
+    ):
+        names_without_wd = []
+
+        for module_name, module in model.named_modules():
+            for param_name, param in module.named_parameters(recurse=False):
+                # Full parameter name includes module and parameter names
+                full_param_name = (
+                    f"{module_name}.{param_name}" if module_name else param_name
+                )
+                # Check if any ban list substring is in the parameter name or module name
+                if (
+                    any(banned in param_name for banned in wd_ban_list)
+                    or any(banned in module_name for banned in wd_ban_list)
+                    or any(banned in module._get_name() for banned in wd_ban_list)
+                ):
+                    names_without_wd.append(full_param_name)
+
+        return names_without_wd
+
+    full_names = find_fully_qualified_names(model_or_parameter, wd_ban_list)
+
     if isinstance(model_or_parameter, nn.Module):
         model_or_parameter = list(model_or_parameter.named_parameters())
-
+    
     return [
         {
-            'params': [p for n, p in model_or_parameter if p.requires_grad and not any(nd in n for nd in wd_ban_list)],
+            'params': [p for n, p in model_or_parameter if p.requires_grad and not any(nd in n for nd in full_names)],
             'weight_decay': weight_decay,
         },
         {
-            'params': [p for n, p in model_or_parameter if p.requires_grad and any(nd in n for nd in wd_ban_list)],
+            'params': [p for n, p in model_or_parameter if p.requires_grad and any(nd in n for nd in full_names)],
             'weight_decay': 0.0,
         },
     ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,7 +98,7 @@ def test_neuron_mean_norm():
 
 def test_get_optimizer_parameters():
     model: nn.Module = Example()
-    wd_ban_list: List[str] = ['bias', 'LayerNorm.bias', 'LayerNorm.weight']
+    wd_ban_list: List[str] = ['bias', 'LayerNorm.bias', 'LayerNorm.weight', 'LayerNorm']
 
     before_parameters = list(model.named_parameters())
     after_parameters = get_optimizer_parameters(model, weight_decay=1e-3, wd_ban_list=wd_ban_list)


### PR DESCRIPTION
## Problem (Why?)

The `wd_ban_list` argument for `get_optimizer_parameters()` is somewhat misleading. When you look at it, you would expect any of the default arguments' name-formats to work correctly. However, that is not the case.
```py
wd_ban_list: List[str] = ('bias', 'LayerNorm.bias', 'LayerNorm.weight')
``` 
From this list, only `bias` is "detected" and "banned" correctly. Neither `LayerNorm.bias` is detected, nor is `LayerNorm.weight`. Neither of these parameters have their `weight_decay` set to 0. 

I even tested `LayerNorm` - and that doesn't work, either.

## Solution (What/How?)

The reason this fails is that the `wd_ban_list` logic is only checking for the actual, fully-qualified parameter names; it is NOT checking for the class name of each `nn.Module`, as `pytorch_optimizer`'s default arguments and tests would imply.

I implemented a more complete method for handling the `wd_ban_list`. Now, we check both for "true names", as well as for `nn.Module` names.

## Notes

I've been using this patch in my own code for several weeks now; it seems to work great! Let me know if there is anything you would change.
