### PR TITLE
[Fix] Add optimizer parameter to PolyScheduler constructor.

### DIFF
--- a/pytorch_optimizer/lr_scheduler/linear_warmup.py
+++ b/pytorch_optimizer/lr_scheduler/linear_warmup.py
@@ -28,13 +28,13 @@ class PolyScheduler(BaseLinearWarmupScheduler):
     :param poly_order: float. lr scheduler decreases with steps.
     """
 
-    def __init__(self, poly_order: float = 0.5, **kwargs):
+    def __init__(self, optimizer, poly_order: float = 0.5, **kwargs):
         self.poly_order = poly_order
 
         if poly_order <= 0:
             raise ValueError(f'[-] poly_order must be positive. {poly_order}')
 
-        super().__init__(**kwargs)
+        super().__init__(optimizer, **kwargs)
 
     def _step(self) -> float:
         return self.min_lr + (self.max_lr - self.min_lr) * (self.step_t - self.warmup_steps) ** self.poly_order


### PR DESCRIPTION
## Problem (Why?)

The `PolySchedulerWithWarmup` raises the following error:

```shell
TypeError: PolySchedulerWithWarmup.__init__() got multiple values for argument 'poly_order'
```

Reproduce the error:

```python
# Dummy optimizer
optimizer = torch.optim.SGD(
    [torch.nn.Parameter(torch.randn(2, 2, requires_grad=True))], lr=0.1
)

poly_scheduler = PolyScheduler(
    optimizer,
    t_max=100,
    max_lr=0.1,
    min_lr=0.01,
    init_lr=0.0,
    warmup_steps=10,
    poly_order=2.0,
)
```

## Solution (What/How?)

Add optimizer parameter to PolyScheduler constructor.

## Other changes (bug fixes, small refactors)

N/A
