### PR TITLE
Fix serialization of state dicts during TRAC/OrthoGrad checkpointing

### DIFF
--- a/pytorch_optimizer/optimizer/orthograd.py
+++ b/pytorch_optimizer/optimizer/orthograd.py
@@ -4,7 +4,7 @@ import torch
 from torch.optim import Optimizer
 
 from pytorch_optimizer.base.optimizer import BaseOptimizer
-from pytorch_optimizer.base.types import CLOSURE, DEFAULTS, LOSS, OPTIMIZER_INSTANCE_OR_CLASS
+from pytorch_optimizer.base.types import CLOSURE, DEFAULTS, LOSS, OPTIMIZER_INSTANCE_OR_CLASS, STATE
 
 
 class OrthoGrad(BaseOptimizer):
@@ -18,10 +18,6 @@ class OrthoGrad(BaseOptimizer):
     def __init__(self, optimizer: OPTIMIZER_INSTANCE_OR_CLASS, **kwargs) -> None:
         self._optimizer_step_pre_hooks: Dict[int, Callable] = {}
         self._optimizer_step_post_hooks: Dict[int, Callable] = {}
-        self._optimizer_state_dict_pre_hooks: Dict[int, Callable] = {}
-        self._optimizer_state_dict_post_hooks: Dict[int, Callable] = {}
-        self._optimizer_load_state_dict_pre_hooks: Dict[int, Callable] = {}
-        self._optimizer_load_state_dict_post_hooks: Dict[int, Callable] = {}
         self.eps: float = 1e-30
 
         if isinstance(optimizer, Optimizer):
@@ -43,7 +39,17 @@ class OrthoGrad(BaseOptimizer):
 
     @property
     def state(self):
-        return self.optimizer.state
+        return {}
+
+    def __getstate__(self):
+        return {'optimizer': self.optimizer}
+
+    def state_dict(self) -> STATE:
+        return {'base_optimizer': self.optimizer.state_dict()}
+
+    def load_state_dict(self, state: STATE):
+        r"""Load state."""
+        self.optimizer.load_state_dict(state['base_optimizer'])
 
     @torch.no_grad()
     def zero_grad(self) -> None:

--- a/pytorch_optimizer/optimizer/orthograd.py
+++ b/pytorch_optimizer/optimizer/orthograd.py
@@ -1,17 +1,10 @@
-from collections import defaultdict
 from typing import Callable, Dict
 
 import torch
 from torch.optim import Optimizer
 
 from pytorch_optimizer.base.optimizer import BaseOptimizer
-from pytorch_optimizer.base.types import (
-    CLOSURE,
-    DEFAULTS,
-    LOSS,
-    OPTIMIZER_INSTANCE_OR_CLASS,
-    STATE,
-)
+from pytorch_optimizer.base.types import CLOSURE, DEFAULTS, LOSS, OPTIMIZER_INSTANCE_OR_CLASS
 
 
 class OrthoGrad(BaseOptimizer):

--- a/pytorch_optimizer/optimizer/orthograd.py
+++ b/pytorch_optimizer/optimizer/orthograd.py
@@ -1,10 +1,17 @@
+from collections import defaultdict
 from typing import Callable, Dict
 
 import torch
 from torch.optim import Optimizer
 
 from pytorch_optimizer.base.optimizer import BaseOptimizer
-from pytorch_optimizer.base.types import CLOSURE, DEFAULTS, LOSS, OPTIMIZER_INSTANCE_OR_CLASS
+from pytorch_optimizer.base.types import (
+    CLOSURE,
+    DEFAULTS,
+    LOSS,
+    OPTIMIZER_INSTANCE_OR_CLASS,
+    STATE,
+)
 
 
 class OrthoGrad(BaseOptimizer):
@@ -18,7 +25,13 @@ class OrthoGrad(BaseOptimizer):
     def __init__(self, optimizer: OPTIMIZER_INSTANCE_OR_CLASS, **kwargs) -> None:
         self._optimizer_step_pre_hooks: Dict[int, Callable] = {}
         self._optimizer_step_post_hooks: Dict[int, Callable] = {}
+        self._optimizer_state_dict_pre_hooks: Dict[int, Callable] = {}
+        self._optimizer_state_dict_post_hooks: Dict[int, Callable] = {}
+        self._optimizer_load_state_dict_pre_hooks: Dict[int, Callable] = {}
+        self._optimizer_load_state_dict_post_hooks: Dict[int, Callable] = {}
         self.eps: float = 1e-30
+
+        self.state: STATE = defaultdict(dict)
 
         if isinstance(optimizer, Optimizer):
             self.optimizer = optimizer
@@ -37,13 +50,8 @@ class OrthoGrad(BaseOptimizer):
     def param_groups(self):
         return self.optimizer.param_groups
 
-    @property
-    def state(self):
-        return self.optimizer.state
-
-    @torch.no_grad()
-    def zero_grad(self) -> None:
-        self.optimizer.zero_grad(set_to_none=True)
+    def __getstate__(self):
+        return {'optimizer': self.optimizer}
 
     @torch.no_grad()
     def reset(self):

--- a/pytorch_optimizer/optimizer/orthograd.py
+++ b/pytorch_optimizer/optimizer/orthograd.py
@@ -31,8 +31,6 @@ class OrthoGrad(BaseOptimizer):
         self._optimizer_load_state_dict_post_hooks: Dict[int, Callable] = {}
         self.eps: float = 1e-30
 
-        self.state: STATE = defaultdict(dict)
-
         if isinstance(optimizer, Optimizer):
             self.optimizer = optimizer
         elif 'params' in kwargs:
@@ -50,8 +48,13 @@ class OrthoGrad(BaseOptimizer):
     def param_groups(self):
         return self.optimizer.param_groups
 
-    def __getstate__(self):
-        return {'optimizer': self.optimizer}
+    @property
+    def state(self):
+        return self.optimizer.state
+
+    @torch.no_grad()
+    def zero_grad(self) -> None:
+        self.optimizer.zero_grad(set_to_none=True)
 
     @torch.no_grad()
     def reset(self):

--- a/pytorch_optimizer/optimizer/trac.py
+++ b/pytorch_optimizer/optimizer/trac.py
@@ -108,6 +108,12 @@ class TRAC(BaseOptimizer):
         eps: float = 1e-8,
         **kwargs,
     ):
+        self._optimizer_step_pre_hooks: Dict[int, Callable] = {}
+        self._optimizer_step_post_hooks: Dict[int, Callable] = {}
+        self._optimizer_state_dict_pre_hooks: Dict[int, Callable] = {}
+        self._optimizer_state_dict_post_hooks: Dict[int, Callable] = {}
+        self._optimizer_load_state_dict_pre_hooks: Dict[int, Callable] = {}
+        self._optimizer_load_state_dict_post_hooks: Dict[int, Callable] = {}
         self.validate_positive(num_coefs, 'num_coefs')
         self.validate_non_negative(s_prev, 's_prev')
         self.validate_non_negative(eps, 'eps')


### PR DESCRIPTION
## Problem (Why?)
Serialization fails during save/load of OrthoGrad:
```
Traceback (most recent call last):
  File "/home/crow/repos/praxis/run.py", line 1130, in <module>
    trainer.fit(
    ~~~~~~~~~~~^
        train_model,
        ^^^^^^^^^^^^
        datamodule,
        ^^^^^^^^^^^
        ckpt_path=ckpt_path,
        ^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/trainer/trainer.py", line 539, in fit
    call._call_and_handle_interrupt(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        self, self._fit_impl, model, train_dataloaders, val_dataloaders, datamodule, ckpt_path
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/trainer/call.py", line 47, in _call_and_handle_interrupt
    return trainer_fn(*args, **kwargs)
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/trainer/trainer.py", line 575, in _fit_impl
    self._run(model, ckpt_path=ckpt_path)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/trainer/trainer.py", line 982, in _run
    results = self._run_stage()
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/trainer/trainer.py", line 1026, in _run_stage
    self.fit_loop.run()
    ~~~~~~~~~~~~~~~~~^^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/loops/fit_loop.py", line 216, in run
    self.advance()
    ~~~~~~~~~~~~^^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/loops/fit_loop.py", line 455, in advance
    self.epoch_loop.run(self._data_fetcher)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/loops/training_epoch_loop.py", line 150, in run
    self.advance(data_fetcher)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/loops/training_epoch_loop.py", line 339, in advance
    call._call_callback_hooks(trainer, "on_train_batch_end", batch_output, batch, batch_idx)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/trainer/call.py", line 222, in _call_callback_hooks
    fn(trainer, trainer.lightning_module, *args, **kwargs)
    ~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/crow/repos/praxis/run.py", line 879, in on_train_batch_end
    self._save_topk_checkpoint(trainer, monitor_candidates)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/callbacks/model_checkpoint.py", line 385, in _save_topk_checkpoint
    self._save_monitor_checkpoint(trainer, monitor_candidates)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/callbacks/model_checkpoint.py", line 705, in _save_monitor_checkpoint
    self._update_best_and_save(current, trainer, monitor_candidates)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/callbacks/model_checkpoint.py", line 757, in _update_best_and_save
    self._save_checkpoint(trainer, filepath)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/callbacks/model_checkpoint.py", line 390, in _save_checkpoint
    trainer.save_checkpoint(filepath, self.save_weights_only)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/trainer/trainer.py", line 1366, in save_checkpoint
    checkpoint = self._checkpoint_connector.dump_checkpoint(weights_only)
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/trainer/connectors/checkpoint_connector.py", line 445, in dump_checkpoint
    optimizer_state = trainer.strategy.optimizer_state(optimizer)
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/lightning/pytorch/strategies/strategy.py", line 190, in optimizer_state
    return optimizer.state_dict()
           ~~~~~~~~~~~~~~~~~~~~^^
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/torch/_compile.py", line 32, in inner
    return disable_fn(*args, **kwargs)
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/torch/_dynamo/eval_frame.py", line 632, in _fn
    return fn(*args, **kwargs)
  File "/home/crow/repos/praxis/.venv/lib/python3.13/site-packages/torch/optim/optimizer.py", line 687, in state_dict
    for pre_hook in self._optimizer_state_dict_pre_hooks.values():
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'OrthoGrad' object has no attribute '_optimizer_state_dict_pre_hooks'. Did you mean: '_optimizer_step_pre_hooks'?
```

## Solution (What/How?)

I added the missing hooks. Though, they should probably be added to `BaseOptimizer` directly.
