### PR TITLE
[Fix] Support alternative precision training in SOAP

### DIFF
--- a/pytorch_optimizer/optimizer/soap.py
+++ b/pytorch_optimizer/optimizer/soap.py
@@ -102,7 +102,7 @@ class SOAP(BaseOptimizer):
 
         for mat in state['Q']:
             if len(mat) > 0:
-                grad = torch.tensordot(grad, mat, dims=[[0], [0 if project_type == 'forward' else 1]])
+                grad = torch.tensordot(grad, mat.to(grad.dtype), dims=[[0], [0 if project_type == 'forward' else 1]])
             else:
                 grad = grad.permute([*list(range(1, len(grad.shape))), 0])
 


### PR DESCRIPTION
Update matrix to use the dtype of the gradient during projection to fix error. Internal representation of float32 is maintained for precision purposes.

Without this fix, non-`float32` models see this error when training:

```
  File "/opt/conda/lib/python3.11/site-packages/pytorch_optimizer/optimizer/soap.py", line 288, in step
    grad_projected = self.project(
                     ^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/pytorch_optimizer/optimizer/soap.py", line 105, in project
    grad = torch.tensordot(grad, mat, dims=[[0], [0 if project_type == 'forward' else 1]])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/functional.py", line 1355, in tensordot
    return _VF.tensordot(a, b, dims_a, dims_b)  # type: ignore[attr-defined]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: both inputs should have same dtype
```

This fix casts the projection matrix to the grad type before its tensordot to ensure dtypes are consistent. The `mat` internal representation remains in f`loat32` to preserve precision of its adjustments and is only cast for projection.
