### PR TITLE
[Feature] Store SOAP condition matrices as the dtype of their parameters

### DIFF
--- a/pytorch_optimizer/optimizer/soap.py
+++ b/pytorch_optimizer/optimizer/soap.py
@@ -126,7 +126,7 @@ class SOAP(BaseOptimizer):
                 _, q = torch.linalg.eigh(m + 1e-30 * torch.eye(m.shape[0], device=m.device, dtype=m.dtype))
             except Exception:  # pragma: no cover
                 _, q = torch.linalg.eigh(
-                    m.to(torch.float64) + 1e-30 * torch.eye(m.shape[0], device=m.device, dtype=m.dtype)
+                    m.to(torch.float64) + 1e-30 * torch.eye(m.shape[0], device=m.device, dtype=torch.float64)
                 )
                 q = q.to(m.dtype)
 

--- a/pytorch_optimizer/optimizer/soap.py
+++ b/pytorch_optimizer/optimizer/soap.py
@@ -269,8 +269,8 @@ class SOAP(BaseOptimizer):
 
                 state = self.state[p]
                 if len(state) == 0:
-                    state['exp_avg'] = torch.zeros_like(grad, dtype=p.dtype)
-                    state['exp_avg_sq'] = torch.zeros_like(grad, dtype=p.dtype)
+                    state['exp_avg'] = torch.zeros_like(grad)
+                    state['exp_avg_sq'] = torch.zeros_like(grad)
 
                     self.init_pre_conditioner(
                         grad,

--- a/pytorch_optimizer/optimizer/soap.py
+++ b/pytorch_optimizer/optimizer/soap.py
@@ -81,8 +81,8 @@ class SOAP(BaseOptimizer):
             for p in group['params']:
                 state = self.state[p]
 
-                state['exp_avg'] = torch.zeros_like(p, dtype=p.dtype)
-                state['exp_avg_sq'] = torch.zeros_like(p, dtype=p.dtype)
+                state['exp_avg'] = torch.zeros_like(p)
+                state['exp_avg_sq'] = torch.zeros_like(p)
 
     def project(
         self,


### PR DESCRIPTION
After https://github.com/kozistr/pytorch_optimizer/pull/333 SOAP functions correctly, but it has significant excess VRAM usage when training models with reduced precision weights (e.g. `bfloat16`).

This PR initializes and updates the condition matrices based on the precision of the parameters themselves rather than defaulting to `float32` for everything.

Note that the only exception to this is [the QR factorization to get the orthogonal Q](https://pytorch.org/docs/stable/generated/torch.linalg.qr.html) is done in `float32`, regardless of the underlying matrix precision, as 

 - only `float32` has CUDA kernel support as of PyTorch 2.5.1
 - precision matters for making the matrix actually orthogonal (I attempted to hand-roll Newton iteration but it was causing NaNs during optimization)
