### PR TITLE
[Fix] momentum in SCION optimizer

### DIFF
--- a/docs/changelogs/v3.6.1.md
+++ b/docs/changelogs/v3.6.1.md
@@ -1,0 +1,5 @@
+## Change Log
+
+### Fix
+
+* Fix to use `momentum buffer` instead of the gradient to calculate LMO. (#385)

--- a/pytorch_optimizer/optimizer/scion.py
+++ b/pytorch_optimizer/optimizer/scion.py
@@ -409,7 +409,7 @@ class SCION(BaseOptimizer):
 
                 d.mul_(1.0 - group['momentum']).add_(grad, alpha=group['momentum'])
 
-                update = norm.lmo(grad).mul_(group['scale'])
+                update = norm.lmo(d).mul_(group['scale'])
 
                 if group['constraint']:
                     p.mul_(1.0 - group['lr'])

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -640,7 +640,7 @@ OPTIMIZERS: List[Tuple[Any, Dict[str, Union[float, bool, int]], int]] = [
     (Kron, {'lr': 1e0, 'weight_decay': 1e-3}, 3),
     (EXAdam, {'lr': 1e-1, 'weight_decay': 1e-3}, 5),
     (SCION, {'lr': 5e-1, 'constraint': False, 'weight_decay': 1e-3}, 5),
-    (SCION, {'lr': 5e-1, 'constraint': True}, 10),
+    (SCION, {'lr': 5e-1, 'constraint': True}, 20),
     (SCIONLight, {'lr': 5e-1, 'constraint': False, 'weight_decay': 1e-3}, 5),
     (SCIONLight, {'lr': 2e-1, 'constraint': True}, 5),
     (AdaGC, {'lr': 1e-1, 'warmup_steps': 2, 'weight_decay': 1e-3}, 5),

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -640,7 +640,7 @@ OPTIMIZERS: List[Tuple[Any, Dict[str, Union[float, bool, int]], int]] = [
     (Kron, {'lr': 1e0, 'weight_decay': 1e-3}, 3),
     (EXAdam, {'lr': 1e-1, 'weight_decay': 1e-3}, 5),
     (SCION, {'lr': 5e-1, 'constraint': False, 'weight_decay': 1e-3}, 5),
-    (SCION, {'lr': 2e-1, 'constraint': True}, 5),
+    (SCION, {'lr': 5e-1, 'constraint': True}, 5),
     (SCIONLight, {'lr': 5e-1, 'constraint': False, 'weight_decay': 1e-3}, 5),
     (SCIONLight, {'lr': 2e-1, 'constraint': True}, 5),
     (AdaGC, {'lr': 1e-1, 'warmup_steps': 2, 'weight_decay': 1e-3}, 5),

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -640,7 +640,7 @@ OPTIMIZERS: List[Tuple[Any, Dict[str, Union[float, bool, int]], int]] = [
     (Kron, {'lr': 1e0, 'weight_decay': 1e-3}, 3),
     (EXAdam, {'lr': 1e-1, 'weight_decay': 1e-3}, 5),
     (SCION, {'lr': 5e-1, 'constraint': False, 'weight_decay': 1e-3}, 5),
-    (SCION, {'lr': 5e-1, 'constraint': True}, 5),
+    (SCION, {'lr': 5e-1, 'constraint': True}, 10),
     (SCIONLight, {'lr': 5e-1, 'constraint': False, 'weight_decay': 1e-3}, 5),
     (SCIONLight, {'lr': 2e-1, 'constraint': True}, 5),
     (AdaGC, {'lr': 1e-1, 'warmup_steps': 2, 'weight_decay': 1e-3}, 5),


### PR DESCRIPTION
## Problem (Why?)

momentum should be used instead of the gradient for the input of the LMO.

## Solution (What/How?)

- [x] `p.grad` to `d`

## Other changes (bug fixes, small refactors)

N/A

## Notes

N/A