### PR TITLE
Fix NaN problem when Grad Norm is zero.

### DIFF
--- a/pytorch_optimizer/optimizer/spam.py
+++ b/pytorch_optimizer/optimizer/spam.py
@@ -407,7 +407,9 @@ class StableSPAM(BaseOptimizer):
                 if mask.sum() > 0:
                     grad[mask].div_(max_grad).mul_(m_max_hat)
 
-                grad_norm = torch.norm(grad)
+                grad_norm = torch.linalg.norm(grad)
+                if grad_norm == 0:
+                    continue
 
                 m_norm_t, v_norm_t = state['m_norm_t'], state['v_norm_t']
                 m_norm_t.lerp_(grad_norm, weight=1.0 - self.gamma1 * scale)


### PR DESCRIPTION

## Problem (Why?)

1. **Norm Function Replacement**  
   `torch.norm(grad)` → `torch.linalg.norm(grad)`  
   Uses the updated PyTorch API for vector norm calculation.

2. **Zero Gradient Handling**  
   Adds a check to skip parameter updates when `grad_norm == 0`. This:
   - Avoids division-by-zero in subsequent calculations
   - Optimizes performance by skipping unnecessary operations
   - Maintains correctness (zero gradients imply no update needed)

## Checklist

- [x] Make sure to run `make format` before commit
- [x] My code adheres to the style guidelines of this project (`make check` shows no errors)
- [x] Both new and existing unit tests pass successfully on my local environment by running `make test`
- [ ] I have made the necessary changes to the documentation
