### PR TITLE
[Update] Eliminate numpy usage and update learning rate application from EXAdam

### DIFF
--- a/pytorch_optimizer/optimizer/exadam.py
+++ b/pytorch_optimizer/optimizer/exadam.py
@@ -1,4 +1,3 @@
-import numpy as np
 import torch
 
 from pytorch_optimizer.base.exception import NoSparseGradientError
@@ -37,8 +36,6 @@ class EXAdam(BaseOptimizer):
         self.validate_non_negative(eps, 'eps')
 
         self.maximize = maximize
-
-        self.sq2: float = np.sqrt(2)
 
         defaults: DEFAULTS = {
             'lr': lr,
@@ -88,8 +85,6 @@ class EXAdam(BaseOptimizer):
             bias_correction1: float = self.debias(beta1, group['step'])
             bias_correction2: float = self.debias(beta2, group['step'])
 
-            step_size: float = group['lr'] * np.log(np.sqrt(group['step'] + 1) * self.sq2)
-
             for p in group['params']:
                 if p.grad is None:
                     continue
@@ -128,6 +123,6 @@ class EXAdam(BaseOptimizer):
 
                 update = (m_tilde + g_tilde) / v_tilde.sqrt().add_(group['eps'])
 
-                p.add_(update, alpha=-step_size)
+                p.add_(update, alpha=-group['lr'])
 
         return loss


### PR DESCRIPTION
## Summary

Removed `numpy` dependency and updated optimizer implementation to reflect the latest [EXAdam paper](https://arxiv.org/abs/2412.20302).  The earlier version of EXAdam used a **dynamic step size** (implemented with `numpy`), but this was removed in the latest paper update.  

## Problem (Why?)

- The previous version relied on `numpy` for calculating the dynamic step size.  
- This added an unnecessary external dependency and complexity in environments where lightweight installation is preferred.  
- The new paper revision no longer uses a dynamic step size, so the implementation needed to be aligned with the updated algorithm.  

## Solution (What/How?)

- Removed all code related to **dynamic step size**, since it is no longer part of the updated EXAdam formulation.  
- Eliminated the `numpy` dependency entirely (step size calculation no longer requires it).  
- Verified optimizer behavior matches the new paper description.

## Notes for Reviewers

- There might be differences in convergence curves compared to the old implementation (since dynamic step size is no longer used).  

## Checklist

- [x] Code formatted with `make format`  
- [x] Code passes style checks (`make check`)  
- [x] All tests pass locally (`make test`)  
- [x] Documentation updated (removed dynamic step size references, updated math notes)  
