### PR TITLE
[Fix] Keep `SignSGD` momentum buffer across steps

### DIFF
--- a/pytorch_optimizer/optimizer/sgd.py
+++ b/pytorch_optimizer/optimizer/sgd.py
@@ -458,7 +458,7 @@ class SignSGD(BaseOptimizer):
 
             state = self.state[p]
 
-            if group['momentum'] > 0.0:
+            if group['momentum'] > 0.0 and 'momentum_buffer' not in state:
                 state['momentum_buffer'] = torch.zeros_like(p)
 
     def _can_use_foreach(self, group: ParamGroup) -> bool:

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -230,6 +230,20 @@ def test_swats_sgd_phase():
     opt.step()
 
 
+@pytest.mark.parametrize('foreach', [False, True])
+def test_sign_sgd_preserves_momentum_buffer(foreach):
+    param = nn.Parameter(torch.tensor([0.0]))
+    optimizer = load_optimizer('signsgd')([param], lr=1.0, momentum=0.9, foreach=foreach)
+
+    param.grad = torch.tensor([1.0])
+    optimizer.step()
+
+    param.grad = torch.tensor([-0.1])
+    optimizer.step()
+
+    assert torch.allclose(optimizer.state[param]['momentum_buffer'], torch.tensor([0.08]))
+
+
 @pytest.mark.parametrize('pre_conditioner_type', [0, 1, 2])
 def test_scalable_shampoo_pre_conditioner_with_svd(pre_conditioner_type):
     model, _ = build_model()


### PR DESCRIPTION
## Problem (Why?)

`SignSGD.init_group()` is called from `step()` on every optimizer step, and when `momentum > 0` it
reassigns `state['momentum_buffer'] = torch.zeros_like(p)` unconditionally. The buffer is zeroed
before every update, so it never carries state from one step to the next.

Since the update is `sign(buf)` and `buf` collapses to `(1 - momentum) * grad`, the positive scale
factor is discarded by `sign`. Signum therefore behaves as plain SignSGD, and `momentum` has no
effect on training. `momentum=0.9` is the constructor default, so `SignSGD(params, lr=...)` is
affected.

A four-value check on a small network, 50 steps each, gives identical loss trajectories and zero
parameter difference:

| momentum | final loss | max abs param diff vs momentum=0 |
|---|---|---|
| 0.0 | 0.7272830606 | 0.0 |
| 0.5 | 0.7272830606 | 0.0 |
| 0.9 | 0.7272830606 | 0.0 |
| 0.99 | 0.7272830606 | 0.0 |

With a constant gradient the buffer stays at `(1 - momentum) * grad` instead of accumulating, and at
an exactly zero gradient the optimizer makes no update where Signum would still step along the
carried moment.

## Solution (What/How?)

Initialise the buffer only when it is absent. `SGDW` (`sgd.py:183`) and `AccSGD` (`sgd.py:71`) in
the same module already use the `if len(state) == 0` pattern.

## Other changes (bug fixes, small refactors)

Added `test_sign_sgd_preserves_momentum_buffer`, parametrised over both `foreach` paths. After two
steps with gradients `1.0` then `-0.1` and `momentum=0.9`, the buffer should be
`0.9 * 0.1 + 0.1 * (-0.1) = 0.08`. On `main` it is `-0.01`.

## Notes

While looking at this I also noticed that `weight_decay` and `weight_decouple` are validated and
stored in `defaults` but never applied in either `SignSGD` step path. I have left that out of this
PR because fixing it changes behaviour for anyone currently passing a non-zero `weight_decay`, which
seems like your call rather than mine. I opened a separate issue for it and am happy to send a patch
if you want one.

`SGDSaI` has the same unguarded initialisation, though it may be intentional there since its state
is set up during warmup. I have not touched it.

## Checklist

- [x] Make sure to run `just format` before commit
- [x] My code adheres to the style guidelines of this project (`just check` shows no errors)
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test`
- [ ] I have made the necessary changes to the documentation

`ruff check` passes on both changed files. I did not run `pyright`, so please flag anything it
catches. The docs box is unticked because I do not think this needs a docs change, but say if it
does.

Test suite before the change: 2486 passed, 2 failed, 433 skipped. After: 2488 passed, 2 failed, 433
skipped. The two failures are `test_complex_optimizers[FTRL_...]` and `test_parse_version`; both
also fail on an unmodified checkout of `main` and are unrelated to this change.
