### PR TITLE
[Fix] Apply weight decay in `SignSGD`

### DIFF
--- a/pytorch_optimizer/optimizer/sgd.py
+++ b/pytorch_optimizer/optimizer/sgd.py
@@ -479,6 +479,15 @@ class SignSGD(BaseOptimizer):
         if self.maximize:
             torch._foreach_neg_(grads)
 
+        self.apply_weight_decay_foreach(
+            params=params,
+            grads=grads,
+            lr=lr,
+            weight_decay=group['weight_decay'],
+            weight_decouple=group['weight_decouple'],
+            fixed_decay=False,
+        )
+
         torch._foreach_lerp_(momentum_buffers, grads, weight=1.0 - group['momentum'])
 
         updates = [buf.sign() for buf in momentum_buffers]
@@ -494,6 +503,15 @@ class SignSGD(BaseOptimizer):
             grad = p.grad
 
             self.maximize_gradient(grad, maximize=self.maximize)
+
+            self.apply_weight_decay(
+                p,
+                grad=grad,
+                lr=group['lr'],
+                weight_decay=group['weight_decay'],
+                weight_decouple=group['weight_decouple'],
+                fixed_decay=False,
+            )
 
             state = self.state[p]
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -244,6 +244,43 @@ def test_sign_sgd_preserves_momentum_buffer(foreach):
     assert torch.allclose(optimizer.state[param]['momentum_buffer'], torch.tensor([0.08]))
 
 
+@pytest.mark.parametrize('foreach', [False, True])
+def test_sign_sgd_decoupled_weight_decay(foreach):
+    param = nn.Parameter(torch.tensor([2.0]))
+    optimizer = load_optimizer('signsgd')(
+        [param], lr=0.1, momentum=0.9, weight_decay=0.2, weight_decouple=True, foreach=foreach
+    )
+
+    param.grad = torch.tensor([0.0])
+    optimizer.step()
+
+    assert torch.allclose(param, torch.tensor([1.96]))
+
+
+@pytest.mark.parametrize('foreach', [False, True])
+def test_sign_sgd_coupled_weight_decay(foreach):
+    param = nn.Parameter(torch.tensor([2.0]))
+    optimizer = load_optimizer('signsgd')(
+        [param], lr=0.1, momentum=0.9, weight_decay=0.2, weight_decouple=False, foreach=foreach
+    )
+
+    param.grad = torch.tensor([0.0])
+    optimizer.step()
+
+    assert torch.allclose(param, torch.tensor([1.9]))
+
+
+@pytest.mark.parametrize('foreach', [False, True])
+def test_sign_sgd_no_weight_decay(foreach):
+    param = nn.Parameter(torch.tensor([2.0]))
+    optimizer = load_optimizer('signsgd')([param], lr=0.1, momentum=0.9, weight_decay=0.0, foreach=foreach)
+
+    param.grad = torch.tensor([0.0])
+    optimizer.step()
+
+    assert torch.allclose(param, torch.tensor([2.0]))
+
+
 @pytest.mark.parametrize('pre_conditioner_type', [0, 1, 2])
 def test_scalable_shampoo_pre_conditioner_with_svd(pre_conditioner_type):
     model, _ = build_model()


### PR DESCRIPTION
## Problem (Why?)

close #517

`SignSGD` validates `weight_decay` and stores it with `weight_decouple` in `defaults`, but neither is
used in either step path, so both are silently ignored.

## Solution (What/How?)

- [x] apply weight decay in `_step_foreach` and `_step_per_param`

Both calls go after gradient maximisation and before the momentum buffer update, following `Tiger`.
`SGDW` applies it after the buffer update instead, which is fine there because `grad = buf` aliases the
buffer; in `SignSGD` the buffer and the gradient stay separate, so decay applied after the lerp would be
dropped for the coupled case.

`fixed_decay=False` is hardcoded as in `SGDW`, since `SignSGD` has no `fixed_decay` argument. Happy to
add one if you would rather have it configurable.

## Other changes (bug fixes, small refactors)

N/A

## Notes

This changes results for anyone currently passing a non-zero `weight_decay`, since it did nothing
before. The default path is unaffected: at `weight_decay=0.0` the parameters are bit-identical to `main`
across momentum, `weight_decouple` and `foreach` settings.

One thing I noticed while testing, not caused by this change: the two step paths can disagree when the
momentum buffer lands near zero, since `_step_per_param` uses `buf.mul_().add_()` and `_step_foreach` uses
`_foreach_lerp_` - algebraically equal, different rounding, and `sign()` turns `1e-17` into a full `lr`
step. It reproduces on `main` at `weight_decay=0.0`. Happy to file it separately.

Three tests added, each parametrised over both `foreach` paths. With `p=2.0`, zero gradient, `lr=0.1`,
`momentum=0.9`, `weight_decay=0.2`: decoupled gives `2.0 * (1 - 0.2 * 0.1) = 1.96`, coupled gives
`grad = 0.2 * 2.0 = 0.4` so the update is `-lr * sign(0.04) = -0.1` and `p = 1.9`. The four decay tests
fail on `main` and pass with this change; the `weight_decay=0.0` test passes on both.

## Checklist

- [x] Make sure to run `just format` before commit
- [x] My code adheres to the style guidelines of this project (`just check` shows no errors)
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test`
- [ ] I have made the necessary changes to the documentation

`ruff check` is clean on both files; I did not run `pyright`. Test suite: 2488 passed before, 2494 after,
with the same two pre-existing failures (`test_complex_optimizers[FTRL_...]` and `test_parse_version`).
