### PR TITLE
[Fix] Match `foreach` and per-parameter rounding in `SignSGD` and `Tiger`

### DIFF
--- a/pytorch_optimizer/optimizer/sgd.py
+++ b/pytorch_optimizer/optimizer/sgd.py
@@ -517,7 +517,7 @@ class SignSGD(BaseOptimizer):
 
             if momentum > 0.0:
                 buf = state['momentum_buffer']
-                buf.mul_(momentum).add_(grad, alpha=1.0 - momentum)
+                buf.lerp_(grad, weight=1.0 - momentum)
             else:
                 buf = grad
 

--- a/pytorch_optimizer/optimizer/tiger.py
+++ b/pytorch_optimizer/optimizer/tiger.py
@@ -127,7 +127,7 @@ class Tiger(BaseOptimizer):
             )
 
             exp_avg = state['exp_avg']
-            exp_avg.mul_(beta).add_(grad, alpha=1.0 - beta)
+            exp_avg.lerp_(grad, weight=1.0 - beta)
 
             p.add_(torch.sign(exp_avg) if not torch.is_complex(exp_avg) else torch.sgn(exp_avg), alpha=-group['lr'])
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -281,6 +281,21 @@ def test_sign_sgd_no_weight_decay(foreach):
     assert torch.allclose(param, torch.tensor([2.0]))
 
 
+@pytest.mark.parametrize(
+    ('optimizer_name', 'kwargs'), [('signsgd', {'momentum': 0.1}), ('tiger', {'beta': 0.1})]
+)
+def test_sign_based_foreach_parity(optimizer_name, kwargs):
+    def run(foreach):
+        param = nn.Parameter(torch.tensor([2.0]))
+        optimizer = load_optimizer(optimizer_name)([param], lr=0.1, foreach=foreach, **kwargs)
+        for grad in (1.0, -0.1):
+            param.grad = torch.tensor([grad])
+            optimizer.step()
+        return param.item()
+
+    assert run(False) == run(True)
+
+
 @pytest.mark.parametrize('pre_conditioner_type', [0, 1, 2])
 def test_scalable_shampoo_pre_conditioner_with_svd(pre_conditioner_type):
     model, _ = build_model()


### PR DESCRIPTION
## Problem (Why?)

Close #519 

Partly addresses #519, the `SignSGD` / `Tiger` half.

`_step_foreach` uses `_foreach_lerp_` while `_step_per_param` uses `mul_().add_()`. Same result in exact
arithmetic, different rounding, and `sign()` turns that into a full step when the buffer lands near zero.

## Solution (What/How?)

- [x] use `lerp_` in `_step_per_param` so both paths round the same way

One line in each. This keeps `_foreach_lerp_` as a single kernel. Moving the `foreach` path to
`_foreach_mul_` + `_foreach_add_` instead would work equally well if you would rather match
`torch.optim.SGD`.

`SGDW` is left alone here, since fixing it changes results for anyone using it with momentum.

## Other changes (bug fixes, small refactors)

N/A

## Notes

Added `test_sign_based_foreach_parity` for both optimizers. It fails on `main` and passes with this change.

## Checklist

- [x] Make sure to run `just format` before commit
- [x] My code adheres to the style guidelines of this project (`just check` shows no errors)
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test`
- [ ] I have made the necessary changes to the documentation

`ruff check` is clean; I did not run `pyright`. Suite: 2494 passed before, 2496 after, same two
pre-existing failures.
