### PR TITLE
Fix AdaSmooth NaN on zero-initialized parameters

### DIFF
--- a/pytorch_optimizer/optimizer/adasmooth.py
+++ b/pytorch_optimizer/optimizer/adasmooth.py
@@ -115,7 +115,7 @@ class AdaSmooth(BaseOptimizer):
                 s.add_(p_diff)
                 n.add_(p_diff.abs())
 
-                c = s.sum().abs_().div_(n.sum())  # e_t
+                c = s.sum().abs_().div_(n.sum().add_(group['eps']))  # e_t
                 c.mul_(beta2 - beta1).add_(1.0 - beta2)
 
                 c_p2 = c.pow(2)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -65,6 +65,20 @@ def test_f32_optimizers(optimizer_config, foreach, environment):
     )
 
 
+def test_adasmooth_zero_initialized_parameter():
+    # AdaSmooth divides by the total absolute parameter movement (sum of |Δp|).
+    # A zero-initialized parameter (e.g. a bias, or a zero-init layer) does not
+    # move on the first step, so the denominator was 0 and the update became
+    # 0 / 0 = NaN, permanently corrupting the parameter.
+    param = nn.Parameter(torch.zeros(4))
+    optimizer = load_optimizer('adasmooth')([param], lr=1e-2)
+    for _ in range(5):
+        optimizer.zero_grad()
+        ((param - 1.0) ** 2).sum().backward()
+        optimizer.step()
+        assert torch.isfinite(param).all()
+
+
 @pytest.mark.parametrize('optimizer_config', OPTIMIZERS, ids=ids)
 @pytest.mark.parametrize('foreach', [False, True])
 def test_bf16_optimizers(optimizer_config, foreach, environment):


### PR DESCRIPTION
### Problem

`AdaSmooth` computes its efficiency ratio by dividing the running signed movement by the running absolute movement:

```python
c = s.sum().abs_().div_(n.sum())  # e_t
```

On the **first step**, a zero-initialized parameter (a bias, or any zero-init layer — very common) has not moved yet: `p_diff` is zero, so `n.sum()` is `0` and the update is `0 / 0 = NaN`, which permanently corrupts the parameter.

```python
import torch
from pytorch_optimizer import AdaSmooth
p = torch.nn.Parameter(torch.zeros(4))
opt = AdaSmooth([p], lr=1e-2)
opt.zero_grad(); ((p - 1.0) ** 2).sum().backward(); opt.step()
print(p)  # tensor([nan, nan, nan, nan]) on main
```

The convergence tests only use randomly-initialized parameters, so this was never hit.

### Fix

Guard the denominator with `eps` (`n.sum() + eps`) so a zero total movement yields a finite ratio; the first-step update is then well-defined and the parameter trains normally. For non-zero parameters `eps` is negligible, so behavior is unchanged.

Added `test_adasmooth_zero_initialized_parameter` (NaN on the current code, finite after the fix). `ruff` clean; the existing adasmooth tests pass.