### PR TITLE
Fix AdaShift NaN on the first update with keep_num > 1

### DIFF
--- a/pytorch_optimizer/optimizer/adashift.py
+++ b/pytorch_optimizer/optimizer/adashift.py
@@ -67,7 +67,7 @@ class AdaShift(BaseOptimizer):
             state = self.state[p]
 
             if len(state) == 0:
-                state['grad_queue'] = deque([grad.clone()], maxlen=group['keep_num'])
+                state['grad_queue'] = deque(maxlen=group['keep_num'])
                 state['exp_avg'] = torch.zeros_like(p)
                 state['exp_avg_sq'] = torch.zeros_like(p)
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -79,6 +79,22 @@ def test_adasmooth_zero_initialized_parameter():
         assert torch.isfinite(param).all()
 
 
+def test_adashift_default_keep_num_does_not_nan():
+    # The gradient queue was pre-seeded with the first gradient, so with the
+    # default keep_num (10) it filled one step early and the first update used
+    # a negative bias correction (debias with a negative step), turning
+    # sqrt(exp_avg_sq / bias_correction) into sqrt of a negative -> NaN. The
+    # existing tests use keep_num=1, which sidesteps this.
+    torch.manual_seed(0)
+    param = nn.Parameter(torch.rand(4))
+    optimizer = load_optimizer('adashift')([param], lr=1e-2)
+    for _ in range(20):
+        optimizer.zero_grad()
+        ((param - 1.0) ** 2).sum().backward()
+        optimizer.step()
+        assert torch.isfinite(param).all()
+
+
 @pytest.mark.parametrize('optimizer_config', OPTIMIZERS, ids=ids)
 @pytest.mark.parametrize('foreach', [False, True])
 def test_bf16_optimizers(optimizer_config, foreach, environment):


### PR DESCRIPTION
### Problem

`AdaShift` NaNs on its first update whenever `keep_num > 1` (the **default is 10**):

```python
import torch
from pytorch_optimizer import AdaShift
p = torch.nn.Parameter(torch.rand(4))
opt = AdaShift([p], lr=1e-2)  # default keep_num=10
for _ in range(20):
    opt.zero_grad(); ((p - 1.0) ** 2).sum().backward(); opt.step()
print(p)  # NaN on main (around the 9th step)
```

`init_group` seeds the gradient queue with the first gradient (`deque([grad.clone()], maxlen=keep_num)`), and `step()` then appends the gradient again — so the queue fills **one step early**. The first update runs at internal step `keep_num - 1`, where

```python
bias_correction = debias(beta2, step - keep_num)  # debias(beta2, -1) -> 1 - beta2**-1 < 0
```

is **negative**. The update is `update.div_(exp_avg_sq.div(bias_correction).sqrt_()...)`, so dividing by a negative and taking the square root yields `sqrt(negative) = NaN`, which permanently corrupts the parameter.

The existing tests only use `keep_num=1` (where the `maxlen=1` queue stays at length 1 and never fills early), so this was never exercised.

### Fix

Initialize the queue empty (`deque(maxlen=keep_num)`) so it fills at the correct step and the first update no longer uses a negative bias correction. Added `test_adashift_default_keep_num_does_not_nan` (NaN on main, finite after the fix); the existing `keep_num=1` tests still pass, `ruff` clean.