### PR TITLE
Fix A2Grad diverging to NaN from an inverted running-mean weight

### DIFF
--- a/pytorch_optimizer/optimizer/a2grad.py
+++ b/pytorch_optimizer/optimizer/a2grad.py
@@ -102,7 +102,7 @@ class A2Grad(BaseOptimizer):
                 state = self.state[p]
 
                 avg_grad, v_k, x_k = state['avg_grad'], state['v_k'], state['x_k']
-                avg_grad.add_(grad - avg_grad, alpha=group['step'] + 1)
+                avg_grad.add_(grad - avg_grad, alpha=1.0 / group['step'])
 
                 delta_k = grad.clone()
                 delta_k.add_(avg_grad, alpha=-1.0)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -79,6 +79,22 @@ def test_adasmooth_zero_initialized_parameter():
         assert torch.isfinite(param).all()
 
 
+def test_a2grad_running_mean_does_not_diverge():
+    # avg_grad is the running mean of gradients (delta_k = grad - avg_grad),
+    # but the incremental-mean update used alpha = step + 1 instead of the
+    # reciprocal 1 / step, so avg_grad grew unboundedly and the optimizer
+    # NaN'd within ~35 steps. The existing tests run too few iterations to
+    # reach the divergence.
+    torch.manual_seed(0)
+    param = nn.Parameter(torch.rand(4))
+    optimizer = load_optimizer('a2grad')([param], lr=1e-2)
+    for _ in range(100):
+        optimizer.zero_grad()
+        ((param - 1.0) ** 2).sum().backward()
+        optimizer.step()
+        assert torch.isfinite(param).all()
+
+
 @pytest.mark.parametrize('optimizer_config', OPTIMIZERS, ids=ids)
 @pytest.mark.parametrize('foreach', [False, True])
 def test_bf16_optimizers(optimizer_config, foreach, environment):


### PR DESCRIPTION
### Problem

`A2Grad` keeps a running mean of gradients — `delta_k = grad - avg_grad` — updated incrementally:

```python
avg_grad.add_(grad - avg_grad, alpha=group['step'] + 1)
```

The weight for an incremental mean is `1 / step`, but this uses `step + 1` — the **reciprocal**. With a growing weight the "average" overshoots the gradient every step and grows without bound, so the optimizer NaNs within ~35 steps for any input:

```
|avg_grad| : step5 ~39  step10 ~1.1e6  step20 ~7.7e17  step30 ~8.4e31  step35 inf  step36 NaN
```

```python
import torch
from pytorch_optimizer import A2Grad
p = torch.nn.Parameter(torch.rand(4))
opt = A2Grad([p], lr=1e-2)
for _ in range(100):
    opt.zero_grad(); ((p - 1.0) ** 2).sum().backward(); opt.step()
print(p)  # NaN on main
```

The existing tests only run a handful of iterations, so they never reach the divergence.

### Fix

Use `alpha = 1 / step` so `avg_grad` is the true running mean (verified: it then matches the exact arithmetic mean of the gradients to float precision, and the optimizer converges). Added `test_a2grad_running_mean_does_not_diverge`; `ruff` clean, existing A2Grad tests pass.