### PR TITLE
Fix M-SVAG NaN from debiasing moments by beta**step instead of 1 - beta**step

### DIFF
--- a/pytorch_optimizer/optimizer/msvag.py
+++ b/pytorch_optimizer/optimizer/msvag.py
@@ -93,8 +93,8 @@ class MSVAG(BaseOptimizer):
                 exp_avg.mul_(beta).add_(grad, alpha=1.0 - beta)
                 exp_avg_sq.mul_(beta).addcmul_(grad, grad, value=1.0 - beta)
 
-                m = exp_avg.div(beta_power)
-                v = exp_avg_sq.div(beta_power)
+                m = exp_avg.div(1.0 - beta_power)
+                v = exp_avg_sq.div(1.0 - beta_power)
 
                 rho: float = self.get_rho(beta_power, beta)
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -111,6 +111,21 @@ def test_adashift_default_keep_num_does_not_nan():
         assert torch.isfinite(param).all()
 
 
+def test_msvag_debiasing_does_not_overflow():
+    # The moment estimates were debiased by dividing by beta ** step, which
+    # underflows toward zero as step grows, so m / v (and the update) explode
+    # and the optimizer NaNs (around step 496). EMA debiasing must divide by
+    # 1 - beta ** step. Run long enough to reach the overflow.
+    torch.manual_seed(0)
+    param = nn.Parameter(torch.rand(4))
+    optimizer = load_optimizer('msvag')([param], lr=1e-2)
+    for _ in range(600):
+        optimizer.zero_grad()
+        ((param - 1.0) ** 2).sum().backward()
+        optimizer.step()
+        assert torch.isfinite(param).all()
+
+
 @pytest.mark.parametrize('optimizer_config', OPTIMIZERS, ids=ids)
 @pytest.mark.parametrize('foreach', [False, True])
 def test_bf16_optimizers(optimizer_config, foreach, environment):


### PR DESCRIPTION
### Problem

M-SVAG debiases its moment estimates by dividing by `beta_power = beta ** step`:

```python
m = exp_avg.div(beta_power)
v = exp_avg_sq.div(beta_power)
```

But `beta ** step` **underflows toward zero** as step grows (`0.9 ** 496 ≈ 1e-23`), so `m` and `v` — and the resulting update — explode, and the optimizer produces NaN around step 496 for any input:

```python
import torch
from pytorch_optimizer import MSVAG
p = torch.nn.Parameter(torch.rand(4))
opt = MSVAG([p], lr=1e-2)
for _ in range(600):
    opt.zero_grad(); ((p - 1.0) ** 2).sum().backward(); opt.step()
print(p)  # NaN on main (~step 496)
```

The standard EMA bias correction divides by `1 - beta ** step` (which approaches 1), not `beta ** step`.

### Fix

Divide the moments by `1 - beta_power`. `beta_power` is still the correct argument to `get_rho` (that formula is M-SVAG's ρ_t and legitimately uses `beta ** step`) — only the two moment divisors were wrong. With the fix M-SVAG converges stably over thousands of steps. Added `test_msvag_debiasing_does_not_overflow`; `ruff` clean, existing M-SVAG tests pass.