### PR TITLE
Fix MADGRAD adding eps to the learning rate

### DIFF
--- a/pytorch_optimizer/optimizer/madgrad.py
+++ b/pytorch_optimizer/optimizer/madgrad.py
@@ -100,7 +100,7 @@ class MADGRAD(BaseOptimizer):
                 self.init_group(group)
 
             weight_decay, momentum, eps = group['weight_decay'], group['momentum'], group['eps']
-            lr: float = group['lr'] + eps
+            lr: float = group['lr']
 
             _lambda = lr * math.pow(self.state['k'] + 1, 0.5)
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -111,6 +111,20 @@ def test_adashift_default_keep_num_does_not_nan():
         assert torch.isfinite(param).all()
 
 
+def test_madgrad_learning_rate_not_inflated_by_eps():
+    # The effective learning rate was `lr + eps`, so eps leaked into the step
+    # size: a step with lr=0 still moved the parameter, and for small learning
+    # rates the eps addition inflated the lr substantially (2x at lr=1e-6). eps
+    # belongs only in the denominator, not added to lr.
+    param = nn.Parameter(torch.tensor([1.0, -2.0, 3.0]))
+    before = param.detach().clone()
+    optimizer = load_optimizer('madgrad')([param], lr=0.0)
+    optimizer.zero_grad()
+    ((param - 5.0) ** 2).sum().backward()
+    optimizer.step()
+    torch.testing.assert_close(param.detach(), before)
+
+
 @pytest.mark.parametrize('optimizer_config', OPTIMIZERS, ids=ids)
 @pytest.mark.parametrize('foreach', [False, True])
 def test_bf16_optimizers(optimizer_config, foreach, environment):


### PR DESCRIPTION
### Problem

MADGRAD computes its step size from `lr + eps`:

```python
lr: float = group['lr'] + eps
_lambda = lr * math.pow(self.state['k'] + 1, 0.5)
```

`eps` is a denominator stabilizer (used in `grad_sum_sq.pow(1/3).add_(eps)`) and should not be part of the learning rate. Because it is, the effective lr is inflated — negligibly for normal lr, but badly for small ones (the fine-tuning / decayed-schedule regime):

| lr | effective (eps=1e-6) | inflation |
|----|----------------------|-----------|
| 1e-3 | 1.001e-3 | ~1x |
| 1e-6 | 2e-6 | **2x** |
| 1e-7 | 1.1e-6 | **11x** |

A step with `lr=0` also still moves the parameter. The reference MADGRAD uses `lamb = lr * sqrt(k + 1)` (no eps on lr).

### Fix

Use `lr` directly; `eps` still stabilizes the cube-root denominator. Added `test_madgrad_learning_rate_not_inflated_by_eps` (lr=0 is now a no-op); `ruff` clean, existing MADGRAD tests pass.