### PR TITLE
Apply the documented `maximize` option in optimizers that ignored it

### DIFF
--- a/pytorch_optimizer/optimizer/demo.py
+++ b/pytorch_optimizer/optimizer/demo.py
@@ -420,6 +420,8 @@ class DeMo(torch.optim.SGD, BaseOptimizer):  # pragma: no cover
                 if torch.is_complex(p):
                     raise NoComplexParameterError(str(self))
 
+                self.maximize_gradient(grad, maximize=self.maximize)
+
                 state = self.demo_state.get(p, {})
 
                 self.apply_weight_decay(

--- a/pytorch_optimizer/optimizer/padam.py
+++ b/pytorch_optimizer/optimizer/padam.py
@@ -101,6 +101,8 @@ class PAdam(BaseOptimizer):
 
                 grad = p.grad
 
+                self.maximize_gradient(grad, maximize=self.maximize)
+
                 state = self.state[p]
 
                 exp_avg, exp_avg_sq = state['exp_avg'], state['exp_avg_sq']

--- a/pytorch_optimizer/optimizer/psgd.py
+++ b/pytorch_optimizer/optimizer/psgd.py
@@ -156,6 +156,8 @@ class Kron(BaseOptimizer):
                 if torch.is_complex(p):
                     raise NoComplexParameterError(str(self))
 
+                self.maximize_gradient(grad, maximize=self.maximize)
+
                 state = self.state[p]
 
                 if len(state) == 0:

--- a/pytorch_optimizer/optimizer/racs.py
+++ b/pytorch_optimizer/optimizer/racs.py
@@ -94,6 +94,8 @@ class RACS(BaseOptimizer):
 
                 state = self.state[p]
 
+                self.maximize_gradient(grad, maximize=self.maximize)
+
                 if grad.ndim < 2:
                     grad = grad.reshape(len(grad), 1)
                 elif grad.ndim > 2:
@@ -294,6 +296,8 @@ class Alice(BaseOptimizer):
                     raise NoComplexParameterError(str(self))
 
                 state = self.state[p]
+
+                self.maximize_gradient(grad, maximize=self.maximize)
 
                 if grad.ndim < 2:
                     grad = grad.reshape(len(grad), 1)

--- a/pytorch_optimizer/optimizer/rose.py
+++ b/pytorch_optimizer/optimizer/rose.py
@@ -118,6 +118,8 @@ class ROSE(BaseOptimizer):
                 grad = p.grad.to(dtype=torch.float32 if fp32 else compute_dtype)
                 param = p.to(dtype=torch.float32 if fp32 else compute_dtype)
 
+                self.maximize_gradient(grad, maximize=self.maximize)
+
                 self.apply_weight_decay(
                     p,
                     grad,

--- a/pytorch_optimizer/optimizer/sgd.py
+++ b/pytorch_optimizer/optimizer/sgd.py
@@ -384,6 +384,8 @@ class ASGD(BaseOptimizer):
                 if grad.is_sparse:
                     raise NoSparseGradientError(str(self))
 
+                self.maximize_gradient(grad, maximize=self.maximize)
+
                 self.apply_weight_decay(
                     p=p,
                     grad=grad,

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1,5 +1,9 @@
+import os
+import socket
+
 import pytest
 import torch
+import torch.distributed as dist
 from torch import nn
 
 from pytorch_optimizer.base.exception import NoClosureError, ZeroParameterSizeError
@@ -1004,3 +1008,78 @@ def test_flash_adamw_parameters():
 
     with pytest.raises(ValueError):
         load_optimizer('flashadamw')([nn.Parameter(torch.ones(1))], master_weight_bits=24)
+
+
+MAXIMIZE_NOOP_CASES = [
+    ('padam', {'lr': 1e0, 'weight_decay': 1e-3}),
+    ('kron', {'lr': 1e0, 'weight_decay': 1e-3, 'pre_conditioner_update_probability': 1.0, 'balance_prob': 0.0}),
+    ('racs', {'lr': 1e0}),
+    ('alice', {'lr': 1e0, 'rank': 2, 'leading_basis': 1, 'update_interval': 2}),
+    ('rose', {'lr': 1e0, 'weight_decay': 1e-3}),
+    ('asgd', {'lr': 5e-1, 'weight_decay': 1e-3}),
+]
+
+
+def _maximize_update_directions(optimizer_name, config):
+    x = torch.randn(8, 2)
+    y = torch.randn(8, 1)
+
+    def run(maximize):
+        torch.manual_seed(42)
+        model = LogisticRegression()
+        init = torch.cat([p.detach().flatten() for p in model.parameters()])
+        optimizer = load_optimizer(optimizer_name)(model.parameters(), maximize=maximize, **config)
+        for _ in range(3):
+            optimizer.zero_grad()
+            torch.manual_seed(1)
+            nn.functional.mse_loss(model(x), y).backward()
+            torch.manual_seed(1)
+            optimizer.step()
+        return torch.cat([p.detach().flatten() for p in model.parameters()]) - init
+
+    return run(maximize=False), run(maximize=True)
+
+
+@pytest.mark.parametrize(('optimizer_name', 'config'), MAXIMIZE_NOOP_CASES)
+def test_maximize_reverses_update_direction(optimizer_name, config):
+    # `maximize=True` must ascend the objective, flipping the update relative to `maximize=False`.
+    # These optimizers accepted and documented the `maximize` option but never applied it in `step`,
+    # so both updates used to be byte-identical.
+    torch.manual_seed(42)
+
+    update_minimize, update_maximize = _maximize_update_directions(optimizer_name, config)
+
+    assert not torch.allclose(update_minimize, update_maximize), 'maximize=True had no effect'
+
+    cosine = torch.cosine_similarity(update_minimize, update_maximize, dim=0)
+    assert cosine < 0.0, f'maximize=True did not reverse the update direction (cosine={cosine:.4f})'
+
+
+def test_demo_maximize_reverses_update_direction():
+    pytest.importorskip('einops')
+
+    if dist.is_available() and dist.is_initialized():
+        pytest.skip('a process group is already initialized')
+
+    with socket.socket() as sock:
+        sock.bind(('127.0.0.1', 0))
+        port = sock.getsockname()[1]
+
+    os.environ['MASTER_ADDR'] = '127.0.0.1'
+    os.environ['MASTER_PORT'] = str(port)
+
+    try:
+        dist.init_process_group(backend='gloo', rank=0, world_size=1)
+    except Exception as exc:  # pragma: no cover - environment dependent
+        pytest.skip(f'cannot initialize a process group: {exc}')
+
+    try:
+        torch.manual_seed(42)
+        update_minimize, update_maximize = _maximize_update_directions('demo', {'lr': 1e0})
+
+        assert not torch.allclose(update_minimize, update_maximize), 'maximize=True had no effect'
+
+        cosine = torch.cosine_similarity(update_minimize, update_maximize, dim=0)
+        assert cosine < 0.0, f'maximize=True did not reverse the update direction (cosine={cosine:.4f})'
+    finally:
+        dist.destroy_process_group()


### PR DESCRIPTION
## Problem (Why?)

Seven optimizers take a `maximize` argument and document it (`maximize (bool): Maximize the objective with respect to the parameters, instead of minimizing.`), but never actually apply it in `step`:

- `PAdam`
- `Kron`
- `RACS`
- `Alice`
- `ROSE`
- `ASGD`
- `DeMo`

Each stores `self.maximize = maximize` in `__init__` but its `step` never calls `maximize_gradient` (nor negates the gradient any other way). So `maximize=True` is a silent no-op — the parameter update is byte-identical to `maximize=False`, and the optimizer minimises the objective regardless of the flag. The `maximize` option was added across the library in #380; these were missed.

Repro (before this change), on any of the above:

```python
# identical params after N steps whether maximize is True or False
```

## Solution (What/How?)

Call `self.maximize_gradient(grad, maximize=self.maximize)` right after the gradient is read, exactly as every other optimizer already does (`AdaSmooth`, `SGDSaI`, `AccSGD`, …). One line per optimizer.

I verified each one end-to-end: on a small model, the parameter update with `maximize=True` is byte-identical to `maximize=False` before the change, and after it the update reverses direction (negative cosine similarity), i.e. gradient ascent.

## Other changes (bug fixes, small refactors)

None — the fix is a single `maximize_gradient` call per optimizer.

## Notes

- Added `test_maximize_reverses_update_direction`, parametrized over the six non-distributed optimizers, asserting that `maximize=True` produces a different update than `maximize=False` **and** reverses its direction (the two used to be identical).
- `DeMo` needs a process group and `einops`, which the test env doesn't provide, so `test_demo_maximize_reverses_update_direction` is guarded with `pytest.importorskip('einops')` and skips cleanly if a process group can't be initialised. I confirmed it locally under a single-process `gloo` group (identical before, reversed after).
- The two unrelated failures I see locally (`CAME` f32 and `FTRL` complex) also fail on a clean `main`, so they're pre-existing and not from this change.

## Checklist

- [x] Make sure to run `just format` before commit
- [x] My code adheres to the style guidelines of this project (`just check` shows no errors)
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test`
- [x] I have made the necessary changes to the documentation (the `maximize` docstrings already describe this behaviour — the fix makes them accurate)