### PR TITLE
Fix Adai ignoring `maximize` (gradient negated twice)

### DIFF
--- a/pytorch_optimizer/optimizer/adai.py
+++ b/pytorch_optimizer/optimizer/adai.py
@@ -150,8 +150,6 @@ class Adai(BaseOptimizer):
 
                 grad = p.grad
 
-                self.maximize_gradient(grad, maximize=self.maximize)
-
                 state = self.state[p]
 
                 if group['stable_weight_decay'] and group['weight_decay'] > 0.0:

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1004,3 +1004,28 @@ def test_flash_adamw_parameters():
 
     with pytest.raises(ValueError):
         load_optimizer('flashadamw')([nn.Parameter(torch.ones(1))], master_weight_bits=24)
+
+
+def test_adai_maximize_reverses_update_direction():
+    # Adai negates the gradient in both of its two passes over the same `p.grad`
+    # (`maximize_gradient` is in-place), so the negations cancelled and `maximize=True`
+    # kept descending the objective. It must reverse the update instead.
+    torch.manual_seed(42)
+    x = torch.randn(8, 2)
+    y = torch.randn(8, 1)
+
+    def run(maximize):
+        torch.manual_seed(42)
+        model = LogisticRegression()
+        init = torch.cat([p.detach().flatten() for p in model.parameters()])
+        optimizer = load_optimizer('adai')(model.parameters(), lr=1e0, weight_decay=1e-3, maximize=maximize)
+        for _ in range(3):
+            optimizer.zero_grad()
+            torch.manual_seed(1)
+            nn.functional.mse_loss(model(x), y).backward()
+            torch.manual_seed(1)
+            optimizer.step()
+        return torch.cat([p.detach().flatten() for p in model.parameters()]) - init
+
+    cosine = torch.cosine_similarity(run(maximize=False), run(maximize=True), dim=0)
+    assert cosine < 0.0, f'maximize=True did not reverse the update direction (cosine={cosine:.4f})'


### PR DESCRIPTION
## Problem (Why?)

`Adai` accepts and documents a `maximize` option, but `maximize=True` doesn't maximise — it keeps minimising the objective.

`maximize_gradient` negates the gradient **in place** (`grad.neg_()`). `Adai.step` makes two passes over the parameters (one to accumulate `exp_avg_sq` and compute the shared mean, one to build `exp_avg` and update), and it calls `maximize_gradient(grad, ...)` on the same `p.grad` in **both** passes. The two in-place negations cancel, so the gradient that reaches `exp_avg` has its original sign and Adai descends regardless of the flag.

With coupled weight decay there's a further wrinkle: the second negation flips the gradient but not the weight-decay term that was already folded into `p.grad` in the first pass, so `maximize=True` isn't even a clean no-op — it produces a subtly wrong update.

## Solution (What/How?)

Remove the **second** `maximize_gradient` call. The first pass already negates the gradient before it feeds `exp_avg_sq` and (for coupled weight decay) `apply_weight_decay`, which is exactly the `maximize`-then-decay order used everywhere else. Since `p.grad` stays negated into the second pass, `exp_avg` then sees the correctly-signed gradient. Removing the second call (rather than the first) keeps the weight-decay sign consistent with the other optimizers.

`maximize=False` is unaffected — `maximize_gradient(grad, maximize=False)` is a no-op, so dropping it changes nothing in the default path.

## Other changes (bug fixes, small refactors)

None.

## Notes

Added `test_adai_maximize_reverses_update_direction`, which asserts the update with `maximize=True` reverses direction relative to `maximize=False`. Before the fix the two point the same way (cosine `+1.0`); after it, they oppose.

## Checklist

- [x] Make sure to run `just format` before commit
- [x] My code adheres to the style guidelines of this project (`just check` shows no errors)
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test`
- [x] I have made the necessary changes to the documentation (the `maximize` docstring already describes this behaviour — the fix makes it accurate)